### PR TITLE
支持 OneBot v11 `clean_cache` API

### DIFF
--- a/src/ntqqapi/hook.ts
+++ b/src/ntqqapi/hook.ts
@@ -24,7 +24,8 @@ export enum ReceiveCmd {
     MEDIA_DOWNLOAD_COMPLETE = "nodeIKernelMsgListener/onRichMediaDownloadComplete",
     UNREAD_GROUP_NOTIFY = "nodeIKernelGroupListener/onGroupNotifiesUnreadCountUpdated",
     GROUP_NOTIFY = "nodeIKernelGroupListener/onGroupSingleScreenNotifies",
-    FRIEND_REQUEST = "nodeIKernelBuddyListener/onBuddyReqChange"
+    FRIEND_REQUEST = "nodeIKernelBuddyListener/onBuddyReqChange",
+    CACHE_SCAN_FINISH = "nodeIKernelStorageCleanListener/onFinishScan",
 }
 
 interface NTQQApiReturnData<PayloadType = unknown> extends Array<any> {

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -766,7 +766,7 @@ export class NTQQApi {
         });
     }
 
-    static getChatCacheList(type: 1 | 2, pageSize: number = 80, pageIndex: number = 0) {
+    static getChatCacheList(type: ChatType, pageSize: number = 80, pageIndex: number = 0) {
         return new Promise<ChatCacheList>((res, rej) => {
             callNTQQApi<ChatCacheList>({
                 methodName: NTQQApiMethod.CACHE_CHAT_GET,

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -16,6 +16,7 @@ import {
     SelfInfo,
     SendMessageElement,
     User,
+    CacheScanResult,
     ChatCacheList,
     ChatCacheListItemBasic
 } from "./types";
@@ -79,7 +80,7 @@ export enum NTQQApiMethod {
     CACHE_PATH_HOT_UPDATE = 'getHotUpdateCachePath', // TODO: Unused method
     CACHE_PATH_DESKTOP_TEMP = 'getDesktopTmpPath', // TODO: Unused method
     CACHE_PATH_SESSION = 'getCleanableAppSessionPathList', // TODO: Unused method
-    CACHE_SCAN = 'nodeIKernelStorageCleanService/scanCache', 
+    CACHE_SCAN = 'nodeIKernelStorageCleanService/scanCache',
     CACHE_CLEAR = '', // TODO
 
     CACHE_CHAT_SCAN = 'nodeIKernelStorageCleanService/getChatCacheInfo',
@@ -704,6 +705,20 @@ export class NTQQApi {
             args: [{
                 isSilent
             }, null]
+        });
+    }
+
+    static scanCache() {
+        callNTQQApi<GeneralCallResult>({
+            channel: NTQQApiChannel.IPC_UP_3,
+            methodName: ReceiveCmd.CACHE_SCAN_FINISH,
+            classNameIsRegister: true,
+        }).then();
+        return callNTQQApi<CacheScanResult>({
+            channel: NTQQApiChannel.IPC_UP_3,
+            methodName: NTQQApiMethod.CACHE_SCAN,
+            args: [null, null],
+            timeoutSecond: 300,
         });
     }
 

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -80,9 +80,9 @@ export enum NTQQApiMethod {
     CACHE_ADD_SCANNED_PATH = 'nodeIKernelStorageCleanService/addCacheScanedPaths', // TODO: Unused method
     CACHE_PATH_HOT_UPDATE = 'getHotUpdateCachePath', // TODO: Unused method
     CACHE_PATH_DESKTOP_TEMP = 'getDesktopTmpPath', // TODO: Unused method
-    CACHE_PATH_SESSION = 'getCleanableAppSessionPathList', // TODO: Unused method
+    CACHE_PATH_SESSION = 'getCleanableAppSessionPathList',
     CACHE_SCAN = 'nodeIKernelStorageCleanService/scanCache',
-    CACHE_CLEAR = '', // TODO
+    CACHE_CLEAR = 'nodeIKernelStorageCleanService/clearCacheDataByKeys',
 
     CACHE_CHAT_GET = 'nodeIKernelStorageCleanService/getChatCacheInfo',
     CACHE_CHAT_CLEAR = 'nodeIKernelStorageCleanService/clearChatCacheInfo',
@@ -732,6 +732,17 @@ export class NTQQApi {
             channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.OS_API,
             methodName: NTQQApiMethod.CACHE_PATH_SESSION,
+        });
+    }
+
+    static clearCache(cacheKeys: Array<string> = [ 'tmp', 'hotUpdate' ]) {
+        console.log(cacheKeys);
+        return callNTQQApi<any>({
+            channel: NTQQApiChannel.IPC_UP_3,
+            methodName: NTQQApiMethod.CACHE_CLEAR,
+            args: [{
+                keys: cacheKeys
+            }, null]
         });
     }
 

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -17,8 +17,8 @@ import {
     SendMessageElement,
     User,
     CacheScanResult,
-    ChatCacheList,
-    ChatCacheListItemBasic
+    ChatCacheList, ChatCacheListItemBasic,
+    CacheFileList, CacheFileListItem, CacheFileType,
 } from "./types";
 import * as fs from "fs";
 import {addHistoryMsg, friendRequests, groupNotifies, msgHistory, selfInfo} from "../common/data";
@@ -87,6 +87,7 @@ export enum NTQQApiMethod {
     CACHE_CLEAR = 'nodeIKernelStorageCleanService/clearCacheDataByKeys',
 
     CACHE_CHAT_GET = 'nodeIKernelStorageCleanService/getChatCacheInfo',
+    CACHE_FILE_GET = 'nodeIKernelStorageCleanService/getFileCacheInfo',
     CACHE_CHAT_CLEAR = 'nodeIKernelStorageCleanService/clearChatCacheInfo',
 }
 
@@ -766,7 +767,7 @@ export class NTQQApi {
         });
     }
 
-    static getChatCacheList(type: ChatType, pageSize: number = 80, pageIndex: number = 0) {
+    static getChatCacheList(type: ChatType, pageSize: number = 1000, pageIndex: number = 0) {
         return new Promise<ChatCacheList>((res, rej) => {
             callNTQQApi<ChatCacheList>({
                 methodName: NTQQApiMethod.CACHE_CHAT_GET,
@@ -779,6 +780,21 @@ export class NTQQApi {
             }).then(list => res(list))
             .catch(e => rej(e));
         });
+    }
+
+    static getFileCacheInfo(fileType: CacheFileType, pageSize: number = 1000, lastRecord?: CacheFileListItem) {
+        const _lastRecord = lastRecord ? lastRecord : { fileType: fileType };
+
+        return callNTQQApi<CacheFileList>({
+            methodName: NTQQApiMethod.CACHE_FILE_GET,
+            args: [{
+                fileType: fileType,
+                restart: true,
+                pageSize: pageSize,
+                order: 1,
+                lastRecord: _lastRecord,
+            }, null]
+        })
     }
 
     static async clearChatCache(chats: ChatCacheListItemBasic[] = [], fileKeys: unknown[] = []) {

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -702,6 +702,7 @@ export class NTQQApi {
 
     static async setCacheSilentScan(isSilent: boolean = true) {
         return await callNTQQApi({
+            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_SET_SILENCE,
             args: [{
                 isSilent
@@ -728,6 +729,7 @@ export class NTQQApi {
             key: string,
             value: string
         }[]>({
+            channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.OS_API,
             methodName: NTQQApiMethod.CACHE_PATH_SESSION,
         });
@@ -736,6 +738,7 @@ export class NTQQApi {
     static getChatCacheList(type: 1 | 2, pageSize: number = 80, pageIndex: number = 0) {
         return new Promise<ChatCacheList>((res, rej) => {
             callNTQQApi<ChatCacheList>({
+                channel: NTQQApiChannel.IPC_UP_3,
                 methodName: NTQQApiMethod.CACHE_CHAT_GET,
                 args: [{
                     ChatType: type,
@@ -750,6 +753,7 @@ export class NTQQApi {
 
     static async clearChatCache(chats: ChatCacheListItemBasic[] = [], fileKeys: unknown[] = []) {
         return await callNTQQApi<GeneralCallResult>({
+            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_CHAT_CLEAR,
             args: [{
                 chats,

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -40,6 +40,7 @@ export type IPCReceiveDetail = [
 export enum NTQQApiClass {
     NT_API = "ns-ntApi",
     FS_API = "ns-FsApi",
+    OS_API = "ns-OsApi",
     GLOBAL_DATA = "ns-GlobalDataApi"
 }
 
@@ -719,6 +720,16 @@ export class NTQQApi {
             methodName: NTQQApiMethod.CACHE_SCAN,
             args: [null, null],
             timeoutSecond: 300,
+        });
+    }
+
+    static getCacheSessionPathList() {
+        return callNTQQApi<{
+            key: string,
+            value: string
+        }[]>({
+            className: NTQQApiClass.OS_API,
+            methodName: NTQQApiMethod.CACHE_PATH_SESSION,
         });
     }
 

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -771,7 +771,7 @@ export class NTQQApi {
             callNTQQApi<ChatCacheList>({
                 methodName: NTQQApiMethod.CACHE_CHAT_GET,
                 args: [{
-                    ChatType: type,
+                    chatType: type,
                     pageSize,
                     order: 1,
                     pageIndex

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -42,6 +42,7 @@ export enum NTQQApiClass {
     FS_API = "ns-FsApi",
     OS_API = "ns-OsApi",
     HOTUPDATE_API = "ns-HotUpdateApi",
+    BUSINESS_API = "ns-BusinessApi",
     GLOBAL_DATA = "ns-GlobalDataApi"
 }
 
@@ -729,6 +730,13 @@ export class NTQQApi {
         return callNTQQApi<string>({
             className: NTQQApiClass.HOTUPDATE_API,
             methodName: NTQQApiMethod.CACHE_PATH_HOT_UPDATE
+        });
+    }
+
+    static getDesktopTmpPath() {
+        return callNTQQApi<string>({
+            className: NTQQApiClass.BUSINESS_API,
+            methodName: NTQQApiMethod.CACHE_PATH_DESKTOP_TEMP
         });
     }
 

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -79,9 +79,9 @@ export enum NTQQApiMethod {
     SET_GROUP_NAME = "nodeIKernelGroupService/modifyGroupName",
 
     CACHE_SET_SILENCE = 'nodeIKernelStorageCleanService/setSilentScan',
-    CACHE_ADD_SCANNED_PATH = 'nodeIKernelStorageCleanService/addCacheScanedPaths', // TODO: Unused method
-    CACHE_PATH_HOT_UPDATE = 'getHotUpdateCachePath', // TODO: Unused method
-    CACHE_PATH_DESKTOP_TEMP = 'getDesktopTmpPath', // TODO: Unused method
+    CACHE_ADD_SCANNED_PATH = 'nodeIKernelStorageCleanService/addCacheScanedPaths',
+    CACHE_PATH_HOT_UPDATE = 'getHotUpdateCachePath',
+    CACHE_PATH_DESKTOP_TEMP = 'getDesktopTmpPath',
     CACHE_PATH_SESSION = 'getCleanableAppSessionPathList',
     CACHE_SCAN = 'nodeIKernelStorageCleanService/scanCache',
     CACHE_CLEAR = 'nodeIKernelStorageCleanService/clearCacheDataByKeys',
@@ -708,6 +708,15 @@ export class NTQQApi {
             methodName: NTQQApiMethod.CACHE_SET_SILENCE,
             args: [{
                 isSilent
+            }, null]
+        });
+    }
+
+    static addCacheScannedPaths(pathMap: object = {}) {
+        return callNTQQApi({
+            methodName: NTQQApiMethod.CACHE_ADD_SCANNED_PATH,
+            args: [{
+                pathMap: {...pathMap},
             }, null]
         });
     }

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -704,7 +704,6 @@ export class NTQQApi {
 
     static async setCacheSilentScan(isSilent: boolean = true) {
         return await callNTQQApi({
-            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_SET_SILENCE,
             args: [{
                 isSilent
@@ -714,7 +713,6 @@ export class NTQQApi {
 
     static addCacheScannedPaths(pathMap: object = {}) {
         return callNTQQApi({
-            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_ADD_SCANNED_PATH,
             args: [{
                 pathMap: {...pathMap},
@@ -724,12 +722,10 @@ export class NTQQApi {
 
     static scanCache() {
         callNTQQApi<GeneralCallResult>({
-            channel: NTQQApiChannel.IPC_UP_3,
             methodName: ReceiveCmd.CACHE_SCAN_FINISH,
             classNameIsRegister: true,
         }).then();
         return callNTQQApi<CacheScanResult>({
-            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_SCAN,
             args: [null, null],
             timeoutSecond: 300,
@@ -738,7 +734,6 @@ export class NTQQApi {
 
     static getHotUpdateCachePath() {
         return callNTQQApi<string>({
-            channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.HOTUPDATE_API,
             methodName: NTQQApiMethod.CACHE_PATH_HOT_UPDATE
         });
@@ -746,7 +741,6 @@ export class NTQQApi {
 
     static getDesktopTmpPath() {
         return callNTQQApi<string>({
-            channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.BUSINESS_API,
             methodName: NTQQApiMethod.CACHE_PATH_DESKTOP_TEMP
         });
@@ -757,7 +751,6 @@ export class NTQQApi {
             key: string,
             value: string
         }[]>({
-            channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.OS_API,
             methodName: NTQQApiMethod.CACHE_PATH_SESSION,
         });
@@ -766,7 +759,6 @@ export class NTQQApi {
     static clearCache(cacheKeys: Array<string> = [ 'tmp', 'hotUpdate' ]) {
         console.log(cacheKeys);
         return callNTQQApi<any>({
-            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_CLEAR,
             args: [{
                 keys: cacheKeys
@@ -777,7 +769,6 @@ export class NTQQApi {
     static getChatCacheList(type: 1 | 2, pageSize: number = 80, pageIndex: number = 0) {
         return new Promise<ChatCacheList>((res, rej) => {
             callNTQQApi<ChatCacheList>({
-                channel: NTQQApiChannel.IPC_UP_3,
                 methodName: NTQQApiMethod.CACHE_CHAT_GET,
                 args: [{
                     ChatType: type,
@@ -792,7 +783,6 @@ export class NTQQApi {
 
     static async clearChatCache(chats: ChatCacheListItemBasic[] = [], fileKeys: unknown[] = []) {
         return await callNTQQApi<GeneralCallResult>({
-            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_CHAT_CLEAR,
             args: [{
                 chats,

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -714,6 +714,7 @@ export class NTQQApi {
 
     static addCacheScannedPaths(pathMap: object = {}) {
         return callNTQQApi({
+            channel: NTQQApiChannel.IPC_UP_3,
             methodName: NTQQApiMethod.CACHE_ADD_SCANNED_PATH,
             args: [{
                 pathMap: {...pathMap},
@@ -737,6 +738,7 @@ export class NTQQApi {
 
     static getHotUpdateCachePath() {
         return callNTQQApi<string>({
+            channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.HOTUPDATE_API,
             methodName: NTQQApiMethod.CACHE_PATH_HOT_UPDATE
         });
@@ -744,6 +746,7 @@ export class NTQQApi {
 
     static getDesktopTmpPath() {
         return callNTQQApi<string>({
+            channel: NTQQApiChannel.IPC_UP_3,
             className: NTQQApiClass.BUSINESS_API,
             methodName: NTQQApiMethod.CACHE_PATH_DESKTOP_TEMP
         });

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -41,6 +41,7 @@ export enum NTQQApiClass {
     NT_API = "ns-ntApi",
     FS_API = "ns-FsApi",
     OS_API = "ns-OsApi",
+    HOTUPDATE_API = "ns-HotUpdateApi",
     GLOBAL_DATA = "ns-GlobalDataApi"
 }
 
@@ -721,6 +722,13 @@ export class NTQQApi {
             methodName: NTQQApiMethod.CACHE_SCAN,
             args: [null, null],
             timeoutSecond: 300,
+        });
+    }
+
+    static getHotUpdateCachePath() {
+        return callNTQQApi<string>({
+            className: NTQQApiClass.HOTUPDATE_API,
+            methodName: NTQQApiMethod.CACHE_PATH_HOT_UPDATE
         });
     }
 

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -83,7 +83,7 @@ export enum NTQQApiMethod {
     CACHE_SCAN = 'nodeIKernelStorageCleanService/scanCache',
     CACHE_CLEAR = '', // TODO
 
-    CACHE_CHAT_SCAN = 'nodeIKernelStorageCleanService/getChatCacheInfo',
+    CACHE_CHAT_GET = 'nodeIKernelStorageCleanService/getChatCacheInfo',
     CACHE_CHAT_CLEAR = 'nodeIKernelStorageCleanService/clearChatCacheInfo',
 }
 
@@ -725,7 +725,7 @@ export class NTQQApi {
     static getChatCacheList(type: 1 | 2, pageSize: number = 80, pageIndex: number = 0) {
         return new Promise<ChatCacheList>((res, rej) => {
             callNTQQApi<ChatCacheList>({
-                methodName: NTQQApiMethod.CACHE_CHAT_SCAN,
+                methodName: NTQQApiMethod.CACHE_CHAT_GET,
                 args: [{
                     ChatType: type,
                     pageSize,

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -15,7 +15,9 @@ import {
     RawMessage,
     SelfInfo,
     SendMessageElement,
-    User
+    User,
+    ChatCacheList,
+    ChatCacheListItemBasic
 } from "./types";
 import * as fs from "fs";
 import {addHistoryMsg, friendRequests, groupNotifies, msgHistory, selfInfo} from "../common/data";
@@ -71,6 +73,17 @@ export enum NTQQApiMethod {
     SET_MEMBER_ROLE = "nodeIKernelGroupService/modifyMemberRole",
     PUBLISH_GROUP_BULLETIN = "nodeIKernelGroupService/publishGroupBulletinBulletin",
     SET_GROUP_NAME = "nodeIKernelGroupService/modifyGroupName",
+
+    CACHE_SET_SILENCE = 'nodeIKernelStorageCleanService/setSilentScan',
+    CACHE_ADD_SCANNED_PATH = 'nodeIKernelStorageCleanService/addCacheScanedPaths', // TODO: Unused method
+    CACHE_PATH_HOT_UPDATE = 'getHotUpdateCachePath', // TODO: Unused method
+    CACHE_PATH_DESKTOP_TEMP = 'getDesktopTmpPath', // TODO: Unused method
+    CACHE_PATH_SESSION = 'getCleanableAppSessionPathList', // TODO: Unused method
+    CACHE_SCAN = 'nodeIKernelStorageCleanService/scanCache', 
+    CACHE_CLEAR = '', // TODO
+
+    CACHE_CHAT_SCAN = 'nodeIKernelStorageCleanService/getChatCacheInfo',
+    CACHE_CHAT_CLEAR = 'nodeIKernelStorageCleanService/clearChatCacheInfo',
 }
 
 enum NTQQApiChannel {
@@ -683,5 +696,39 @@ export class NTQQApi {
 
     static publishGroupBulletin(groupQQ: string, title: string, content: string) {
 
+    }
+
+    static async setCacheSilentScan(isSilent: boolean = true) {
+        return await callNTQQApi({
+            methodName: NTQQApiMethod.CACHE_SET_SILENCE,
+            args: [{
+                isSilent
+            }, null]
+        });
+    }
+
+    static getChatCacheList(type: 1 | 2, pageSize: number = 80, pageIndex: number = 0) {
+        return new Promise<ChatCacheList>((res, rej) => {
+            callNTQQApi<ChatCacheList>({
+                methodName: NTQQApiMethod.CACHE_CHAT_SCAN,
+                args: [{
+                    ChatType: type,
+                    pageSize,
+                    order: 1,
+                    pageIndex
+                }, null]
+            }).then(list => res(list))
+            .catch(e => rej(e));
+        });
+    }
+
+    static async clearChatCache(chats: ChatCacheListItemBasic[] = [], fileKeys: unknown[] = []) {
+        return await callNTQQApi<GeneralCallResult>({
+            methodName: NTQQApiMethod.CACHE_CHAT_CLEAR,
+            args: [{
+                chats,
+                fileKeys
+            }, null]
+        });
     }
 }

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -704,7 +704,7 @@ export class NTQQApi {
     }
 
     static async setCacheSilentScan(isSilent: boolean = true) {
-        return await callNTQQApi({
+        return await callNTQQApi<GeneralCallResult>({
             methodName: NTQQApiMethod.CACHE_SET_SILENCE,
             args: [{
                 isSilent
@@ -713,7 +713,7 @@ export class NTQQApi {
     }
 
     static addCacheScannedPaths(pathMap: object = {}) {
-        return callNTQQApi({
+        return callNTQQApi<GeneralCallResult>({
             methodName: NTQQApiMethod.CACHE_ADD_SCANNED_PATH,
             args: [{
                 pathMap: {...pathMap},
@@ -758,8 +758,7 @@ export class NTQQApi {
     }
 
     static clearCache(cacheKeys: Array<string> = [ 'tmp', 'hotUpdate' ]) {
-        console.log(cacheKeys);
-        return callNTQQApi<any>({
+        return callNTQQApi<any>({ // TODO: 目前还不知道真正的返回值是什么
             methodName: NTQQApiMethod.CACHE_CLEAR,
             args: [{
                 keys: cacheKeys
@@ -797,7 +796,7 @@ export class NTQQApi {
         })
     }
 
-    static async clearChatCache(chats: ChatCacheListItemBasic[] = [], fileKeys: unknown[] = []) {
+    static async clearChatCache(chats: ChatCacheListItemBasic[] = [], fileKeys: string[] = []) {
         return await callNTQQApi<GeneralCallResult>({
             methodName: NTQQApiMethod.CACHE_CHAT_CLEAR,
             args: [{

--- a/src/ntqqapi/types.ts
+++ b/src/ntqqapi/types.ts
@@ -377,7 +377,7 @@ export interface ChatCacheList {
 }
 
 export interface ChatCacheListItem {
-    chatType: 1 | 2,
+    chatType: ChatType,
     basicChatCacheInfo: ChatCacheListItemBasic,
     guildChatCacheInfo: unknown[] // TODO: 没用过频道所以不知道这里边的详细内容
 }
@@ -389,6 +389,6 @@ export interface ChatCacheListItemBasic {
     uin: string,
     remarkName: string,
     nickName: string,
-    chatType?: 1 | 2,
+    chatType?: ChatType,
     isChecked?: boolean
 }

--- a/src/ntqqapi/types.ts
+++ b/src/ntqqapi/types.ts
@@ -392,3 +392,30 @@ export interface ChatCacheListItemBasic {
     chatType?: ChatType,
     isChecked?: boolean
 }
+
+export enum CacheFileType {
+    IMAGE = 0,
+    VIDEO = 1,
+    AUDIO = 2,
+    DOCUMENT = 3,
+    OTHER = 4,
+}
+
+export interface CacheFileList {
+    infos: CacheFileListItem[],
+}
+
+export interface CacheFileListItem {
+    fileSize: string,
+    fileTime: string,
+    fileKey: string,
+    elementId: string,
+    elementIdStr: string,
+    fileType: CacheFileType,
+    path: string,
+    fileName: string,
+    senderId: string,
+    previewPath: string,
+    senderName: string,
+    isChecked?: boolean,
+}

--- a/src/ntqqapi/types.ts
+++ b/src/ntqqapi/types.ts
@@ -355,3 +355,22 @@ export interface FriendRequestNotify {
         buddyReqs: FriendRequest[]
     }
 }
+export interface ChatCacheList {
+    pageCount: number,
+    infos: ChatCacheListItem[]
+}
+
+export interface ChatCacheListItem {
+    chatType: 1 | 2,
+    basicChatCacheInfo: ChatCacheListItemBasic,
+    guildChatCacheInfo: unknown[] // TODO: 没用过频道所以不知道这里边的详细内容
+}
+
+export interface ChatCacheListItemBasic {
+    chatSize: string,
+    chatTime: string,
+    uid: string,
+    uin: string,
+    remarkName: string,
+    nickName: string
+}

--- a/src/ntqqapi/types.ts
+++ b/src/ntqqapi/types.ts
@@ -355,6 +355,22 @@ export interface FriendRequestNotify {
         buddyReqs: FriendRequest[]
     }
 }
+
+export interface CacheScanResult {
+    result: number,
+    size: [ // 单位为字节
+        string, // 系统总存储空间
+        string, // 系统可用存储空间
+        string, // 系统已用存储空间
+        string, // QQ总大小
+        string, // 「聊天与文件」大小
+        string, // 未知
+        string, // 「缓存数据」大小
+        string, // 「其他数据」大小
+        string, // 未知
+    ]
+}
+
 export interface ChatCacheList {
     pageCount: number,
     infos: ChatCacheListItem[]
@@ -372,5 +388,7 @@ export interface ChatCacheListItemBasic {
     uid: string,
     uin: string,
     remarkName: string,
-    nickName: string
+    nickName: string,
+    chatType?: 1 | 2,
+    isChecked?: boolean
 }

--- a/src/onebot11/action/CleanCache.ts
+++ b/src/onebot11/action/CleanCache.ts
@@ -1,0 +1,96 @@
+import BaseAction from "./BaseAction";
+import {ActionName} from "./types";
+import {NTQQApi} from "../../ntqqapi/ntcall";
+import fs from "fs";
+import Path from "path";
+import {
+    ChatType,
+    ChatCacheListItemBasic
+} from '../../ntqqapi/types';
+
+export default class CleanCache extends BaseAction<void, void> {
+    actionName = ActionName.CleanCache
+
+    protected _handle(): Promise<void> {
+        console.log('Start scanning cache...');
+        return new Promise<void>(async (res, rej) => {
+            try {
+                const cacheFilePaths: string[] = [];
+
+                await NTQQApi.setCacheSilentScan(false);
+
+                cacheFilePaths.push((await NTQQApi.getHotUpdateCachePath()));
+                cacheFilePaths.push((await NTQQApi.getDesktopTmpPath()));
+                (await NTQQApi.getCacheSessionPathList()).forEach(e => cacheFilePaths.push(e.value));
+
+                // await NTQQApi.addCacheScannedPaths(); // XXX: 调用就崩溃，原因目前还未知
+                const cacheScanResult = await NTQQApi.scanCache();
+                const cacheSize = parseInt(cacheScanResult.size[6]);
+
+                if (cacheScanResult.result !== 0) {
+                    throw('Something went wrong while scanning cache. Code: ' + cacheScanResult.result);
+                }
+
+                await NTQQApi.setCacheSilentScan(true);
+                if (cacheSize > 0 && cacheFilePaths.length > 2) { // 存在缓存文件且大小不为 0 时执行清理动作
+                    console.log('Cleaning cache...');
+                    // await NTQQApi.clearCache([ 'tmp', 'hotUpdate', ...cacheScanResult ]) // XXX: 也是调用就崩溃，调用 fs 删除得了
+                    deleteCachePath(cacheFilePaths);
+                }
+
+                // 清理聊天记录
+                // NOTE: 以防有人不需要删除聊天记录，暂时先注释掉，日后加个开关
+                // await clearChatCache(ChatCacheType.PRIVATE); // 私聊消息
+                // await clearChatCache(ChatCacheType.GROUP); // 群聊消息
+
+
+
+                res();
+            } catch(e) {
+                console.error('清理缓存时发生了错误');
+                rej(e);
+            }
+        });
+    }
+}
+
+function deleteCachePath(pathList: string[]) {
+    const emptyPath = (path: string) => {
+        if (!fs.existsSync(path)) return;
+        const files = fs.readdirSync(path);
+        files.forEach(file => {
+            const filePath = Path.resolve(path, file);
+            const stats = fs.statSync(filePath);
+            if (stats.isDirectory()) emptyPath(filePath);
+            else fs.unlinkSync(filePath);
+        });
+        fs.rmdirSync(path);
+    }
+
+    for (const path of pathList) {
+        emptyPath(path);
+    }
+}
+
+async function clearChatCache(type: ChatCacheType) {
+    const cacheList = await getCacheList(type);
+    return NTQQApi.clearChatCache(cacheList, []);
+}
+
+function getCacheList(type: ChatCacheType) { // NOTE: 做这个方法主要是因为目前还不支持针对频道消息的清理
+    return new Promise<Array<ChatCacheListItemBasic>>((res, rej) => {
+        NTQQApi.getChatCacheList(type, 1000, 0)
+            .then(data => {
+                console.log(data);
+                const list = data.infos.filter(e => e.chatType === type && parseInt(e.basicChatCacheInfo.chatSize) > 0);
+                const result = list.map(e => {
+                    const result = { ...e.basicChatCacheInfo };
+                    result.chatType = type;
+                    result.isChecked = true;
+                    return result;
+                });
+                res(result);
+            })
+            .catch(e => rej(e));
+    });
+}

--- a/src/onebot11/action/CleanCache.ts
+++ b/src/onebot11/action/CleanCache.ts
@@ -40,8 +40,8 @@ export default class CleanCache extends BaseAction<void, void> {
 
                 // 清理聊天记录
                 // NOTE: 以防有人不需要删除聊天记录，暂时先注释掉，日后加个开关
-                // await clearChatCache(ChatCacheType.PRIVATE); // 私聊消息
-                // await clearChatCache(ChatCacheType.GROUP); // 群聊消息
+                // await clearChatCache(ChatType.PRIVATE); // 私聊消息
+                // await clearChatCache(ChatType.GROUP); // 群聊消息
 
 
 
@@ -72,12 +72,12 @@ function deleteCachePath(pathList: string[]) {
     }
 }
 
-async function clearChatCache(type: ChatCacheType) {
+async function clearChatCache(type: ChatType) {
     const cacheList = await getCacheList(type);
     return NTQQApi.clearChatCache(cacheList, []);
 }
 
-function getCacheList(type: ChatCacheType) { // NOTE: 做这个方法主要是因为目前还不支持针对频道消息的清理
+function getCacheList(type: ChatType) { // NOTE: 做这个方法主要是因为目前还不支持针对频道消息的清理
     return new Promise<Array<ChatCacheListItemBasic>>((res, rej) => {
         NTQQApi.getChatCacheList(type, 1000, 0)
             .then(data => {

--- a/src/onebot11/action/index.ts
+++ b/src/onebot11/action/index.ts
@@ -28,6 +28,7 @@ import SetGroupBan from "./SetGroupBan";
 import SetGroupKick from "./SetGroupKick";
 import SetGroupAdmin from "./SetGroupAdmin";
 import SetGroupCard from "./SetGroupCard";
+import CleanCache from "./CleanCache";
 
 export const actionHandlers = [
     new Debug(),
@@ -51,6 +52,7 @@ export const actionHandlers = [
     new SetGroupAdmin(),
     new SetGroupName(),
     new SetGroupCard(),
+    new CleanCache(),
 
     //以下为go-cqhttp api
     new GoCQHTTPSendGroupForwardMsg(),

--- a/src/onebot11/action/types.ts
+++ b/src/onebot11/action/types.ts
@@ -40,6 +40,7 @@ export enum ActionName {
     SetGroupAdmin = "set_group_admin",
     SetGroupCard = "set_group_card",
     SetGroupName = "set_group_name",
+    CleanCache = "clean_cache",
     // 以下为go-cqhttp api
     GoCQHTTP_SendGroupForwardMsg = "send_group_forward_msg",
     GoCQHTTP_SendPrivateForwardMsg = "send_private_forward_msg",


### PR DESCRIPTION
参阅 [OneBot v11 文档](https://github.com/botuniverse/onebot-11/blob/master/api/public.md#clean_cache-%E6%B8%85%E7%90%86%E7%BC%93%E5%AD%98)

## 目前进度
* [x] 删除本体缓存文件
* [x] 删除聊天记录
* [ ] 删除频道聊天记录
* [x] 删除聊天缓存文件

## 备注
* 因为我没用过频道所以不知道频道聊天记录是什么格式
* 考虑到部分用户可能不需要删除聊天记录，故删除聊天记录相关的代码在提交的时候是被注释掉的，日后可以选择增加一个开关在设置页里
* 虽然尝试抓取和实现了内部的本体缓存清理 API，但是因未知原因一调用就崩溃，故自己另外造了轮子
