### PR TITLE
新增群禁言事件 操作者和目标的名称

### DIFF
--- a/src/onebot11/constructor.ts
+++ b/src/onebot11/constructor.ts
@@ -271,7 +271,7 @@ export class OB11Constructor {
                     }
                     const adminUin = (await getGroupMember(msg.peerUid, adminUid))?.uin || (await NTQQUserApi.getUserDetailInfo(adminUid))?.uin
                     if (memberUin && adminUin) {
-                        return new OB11GroupBanEvent(parseInt(msg.peerUid), parseInt(memberUin), parseInt(adminUin), duration, sub_type);
+                        return new OB11GroupBanEvent(parseInt(msg.peerUid), parseInt(memberUin), parseInt(adminUin), groupElement.shutUp.member.name, groupElement.shutUp.admin.name, groupElement.shutUp.member.card, groupElement.shutUp.admin.card, duration, sub_type);
                     }
                 }
             } else if (element.fileElement) {

--- a/src/onebot11/event/notice/OB11GroupBanEvent.ts
+++ b/src/onebot11/event/notice/OB11GroupBanEvent.ts
@@ -3,15 +3,23 @@ import {OB11GroupNoticeEvent} from "./OB11GroupNoticeEvent";
 export class OB11GroupBanEvent extends OB11GroupNoticeEvent {
     notice_type = "group_ban";
     operator_id: number;
+    member_name: string;
+    admin_name: string;
+    member_card: string;
+    admin_card: string;
     duration: number;
     sub_type: "ban" | "lift_ban";
 
-    constructor(groupId: number, userId: number, operatorId: number, duration: number, sub_type:  "ban" | "lift_ban") {
+    constructor(groupId: number, userId: number, operatorId: number, memberName: string, adminName: string, memberCard: string, adminCard: string, duration: number, sub_type:  "ban" | "lift_ban") {
         super();
         this.group_id = groupId;
         this.operator_id = operatorId;
         this.user_id = userId;
         this.duration = duration;
         this.sub_type = sub_type;
+        this.member_name = memberName;
+        this.admin_name = adminName;
+        this.member_card = memberCard;
+        this.admin_card = adminCard;
     }
 }


### PR DESCRIPTION
增加了 "member_name" "admin_name" "member_card" "admin_card" 字段
方便可以直接发布谁禁言了谁的消息.