### PR TITLE
修复rkey缺失导致的某些图片无法获取

### DIFF
--- a/src/onebot11/constructor.ts
+++ b/src/onebot11/constructor.ts
@@ -141,7 +141,11 @@ export class OB11Constructor {
                 const url = element.picElement.originImageUrl
                 const fileMd5 = element.picElement.md5HexStr
                 if (url) {
-                    message_data["data"]["url"] = IMAGE_HTTP_HOST + url
+                    if (url.startsWith("/download")) {
+                        message_data["data"]["url"] = IMAGE_HTTP_HOST + url + "&rkey=CAQSKAB6JWENi5LMk0kc62l8Pm3Jn1dsLZHyRLAnNmHGoZ3y_gDZPqZt-64"
+                    } else {
+                        message_data["data"]["url"] = IMAGE_HTTP_HOST + url
+                    }
                 } else if (fileMd5 && element.picElement.fileUuid.indexOf("_") === -1) { // fileuuid有下划线的是Linux发送的，这个url是另外的格式，目前尚未得知如何组装
                     message_data["data"]["url"] = `${IMAGE_HTTP_HOST}/gchatpic_new/0/0-0-${fileMd5.toUpperCase()}/0`
                 }


### PR DESCRIPTION
在某些情况下会获取到gchat.qpic.cn/download开头的图片url.该url会因rkey字段缺失导致尝试获取图像时服务器返回HTTP 400
修正方法参照https://github.com/whitechi73/OpenShamrock/commit/2c8094c8c8337fcd7d4afbc68e40746accfb5b79