### PR TITLE
feat: add nickname to message as key `nick`

### DIFF
--- a/src/onebot11/constructor.ts
+++ b/src/onebot11/constructor.ts
@@ -270,6 +270,7 @@ export class OB11Constructor {
         message_data['data']['emoji_id'] = element.marketFaceElement.emojiId
         message_data['data']['emoji_package_id'] = String(element.marketFaceElement.emojiPackageId)
         message_data['data']['key'] = element.marketFaceElement.key
+        message_data['data']['name'] = element.marketFaceElement.faceName
         mFaceCache.set(md5, element.marketFaceElement.faceName)
       }
       else if (element.markdownElement) {

--- a/src/onebot11/event/OB11BaseEvent.ts
+++ b/src/onebot11/event/OB11BaseEvent.ts
@@ -11,5 +11,6 @@ export enum EventType {
 export abstract class OB11BaseEvent {
   time = Math.floor(Date.now() / 1000)
   self_id = parseInt(selfInfo.uin)
+  nick = selfInfo.nick
   post_type: EventType
 }


### PR DESCRIPTION
Including nickname as `nick` into `OB11BaseEvent` increases readability