### PR TITLE
fix: #215 get_forward_msg params missing id(onebot11)

### DIFF
--- a/src/onebot11/action/go-cqhttp/GetForwardMsg.ts
+++ b/src/onebot11/action/go-cqhttp/GetForwardMsg.ts
@@ -6,7 +6,8 @@ import { OB11Constructor } from '../../constructor'
 import { ActionName } from '../types'
 
 interface Payload {
-  message_id: string // long msg id
+  message_id: string // long msg id，gocq
+  id?: string // long msg id, onebot11
 }
 
 interface Response {
@@ -16,7 +17,11 @@ interface Response {
 export class GoCQHTTGetForwardMsgAction extends BaseAction<Payload, any> {
   actionName = ActionName.GoCQHTTP_GetForwardMsg
   protected async _handle(payload: Payload): Promise<any> {
-    const rootMsg = await dbUtil.getMsgByLongId(payload.message_id)
+    const message_id = payload.id || payload.message_id
+    if (!message_id) {
+      throw Error('message_id不能为空')
+    }
+    const rootMsg = await dbUtil.getMsgByLongId(message_id)
     if (!rootMsg) {
       throw Error('msg not found')
     }


### PR DESCRIPTION
gocq 的 get_forward_msg 接口用的是 `message_id`，而 OneBot11 用的是 `id`