### PR TITLE
fix: skip problematic name-value pairs in encodeCQCode to prevent undefined errors

### DIFF
--- a/src/onebot11/cqcode.ts
+++ b/src/onebot11/cqcode.ts
@@ -61,6 +61,14 @@ export function encodeCQCode(data: OB11MessageData) {
   let result = '[CQ:' + data.type
   for (const name in data.data) {
     const value = data.data[name]
+    try {
+      // Check if the value can be converted to a string
+      value.toString();
+    } catch (error) {
+      // If it can't be converted, skip this name-value pair
+      // console.warn(`Skipping problematic name-value pair. Name: ${name}, Value: ${value}`);
+      continue;
+    }
     result += `,${name}=${CQCodeEscape(value)}`
   }
   result += ']'


### PR DESCRIPTION
在 `encodeCQCode` 中，当处理的数据包含无法转换为字符串的值（例如 undefined）时，会引发 TypeError 错误，导致无法继续执行。主要发生在对数据进行编码时，某些值不能调用 toString 方法。  

https://github.com/LLOneBot/LLOneBot/blob/bc4511e1752884004473f3cb19a7800563d1bfe9/src/onebot11/cqcode.ts#L62-L65
https://github.com/LLOneBot/LLOneBot/blob/bc4511e1752884004473f3cb19a7800563d1bfe9/src/onebot11/cqcode.ts#L52-L55

可以使用如下代码进行测试
``` TypeScript
let result = "[CQ:" + data.type;
for (const name in data.data) {
  const value = data.data[name];
  try {
    // Check if the value can be converted to a string
    value.toString();
  } catch (error) {
    // If it can't be converted, throw an error with the necessary information
    throw new Error(`Cannot convert value to string. Data: ${JSON.stringify(data)}, Result so far: ${result}, Problematic name: ${name}, Problematic value: ${value}`);
  }
  result += `,${name}=${CQCodeEscape(value)}`;
}
result += "]";
return result;
```
当出现问题时，会得到如下报错：
```Log
gocq api error
api: get_group_msg_history
retcode: 1200
message: (Error: Cannot convert value to string. Data: {"data":{"file":"a7c60d5c44ad304e1713e1e8295feae2.mp4","path":"C:\\Users\\Administrator\\Documents\\Tencent Files\\1234\\nt_qq\\nt_data\\Video\\2024-07\\Ori\\a7c60d5c44ad304e1713e1e8295feae2.mp4","file_id":"NTV2COMPAT.Ck4IARpIQ2drNU5qUTFPRGszTnpJU0ZPQ3RGZUVMUHZQb0NaeFFWdGJ4Y2ViVGM1TEpHTV9QaWdNZ2h3c28wcHJrcGFDeWh3TlFnUFVrIAIKTwgBEGQaR0NnazVOalExT0RrM056SVNGQTd3YWtNd2pDMFp4WXRvZFlBUWZNenM1OVNYR01LNUVpQ0lDeWpxaGVlbG9MS0hBMUNBOVNRIAI","file_size":"6465487"},"type":"video"}, Result so far: [CQ:video,file=a7c60d5c44ad304e1713e1e8295feae2.mp4,path=C:\Users\Administrator\Documents\Tencent Files\1234\nt_qq\nt_data\Video\2024-07\Ori\a7c60d5c44ad304e1713e1e8295feae2.mp4,file_id=NTV2COMPAT.Ck4IARpIQ2drNU5qUTFPRGszTnpJU0ZPQ3RGZUVMUHZQb0NaeFFWdGJ4Y2ViVGM1TEpHTV9QaWdNZ2h3c28wcHJrcGFDeWh3TlFnUFVrIAIKTwgBEGQaR0NnazVOalExT0RrM056SVNGQTd3YWtNd2pDMFp4WXRvZFlBUWZNenM1OVNYR01LNUVpQ0lDeWpxaGVlbG9MS0hBMUNBOVNRIAI,file_size=6465487, Problematic name: url, Problematic value: undefined
    at encodeCQCode (D:\QQNT\resources\app\LiteLoaderQQNT-main\plugins\LLOneBot\main\main.cjs:33857:13)
    at OB11Constructor.message (D:\QQNT\resources\app\LiteLoaderQQNT-main\plugins\LLOneBot\main\main.cjs:35705:24)
    at async Promise.all (index 84)
    at async GoCQHTTPGetGroupMsgHistory._handle (D:\QQNT\resources\app\LiteLoaderQQNT-main\plugins\LLOneBot\main\main.cjs:82997:25)
    at async GoCQHTTPGetGroupMsgHistory.websocketHandle (D:\QQNT\resources\app\LiteLoaderQQNT-main\plugins\LLOneBot\main\main.cjs:33736:23)
    at async OB11WebsocketServer.handleAction (D:\QQNT\resources\app\LiteLoaderQQNT-main\plugins\LLOneBot\main\main.cjs:83260:26))[failed]
```
此例子中出现于video元素，其data中不包含url，但是encodeCQCode时会由于url为undefined从而在toString()时报错

此问题会出现在GetGroupMsgHistory和获取转发消息记录中包含了Vidio时，但是我不确定对于File等是否也会有类似情况。