### PR TITLE
fix: lack of preparation before initiating a temporary chat

### DIFF
--- a/src/ntqqapi/api/msg.ts
+++ b/src/ntqqapi/api/msg.ts
@@ -157,6 +157,23 @@ export class NTQQMsgApi {
     }
   }
 
+  static async prepareTempMessage(uid: string, fromGroup: string) {
+    return await invoke({
+      methodName: NTMethod.PREPARE_TEMP_CHAT,
+      args: [{
+        preInfo: {
+          chatType: 100,
+          peerUid: uid,
+          fromGroupCode: fromGroup.toString(),
+          sig: '',
+          peerNickname: '',
+          selfUid: '',
+          selfPhone: ''
+        }
+      }, undefined]
+    })
+  }
+
   static async sendMsg(peer: Peer, msgElements: SendMessageElement[], waitComplete = true, timeout = 10000) {
     const msgId = generateMsgId()
     peer.guildId = msgId

--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -48,6 +48,7 @@ export enum NTMethod {
 
   RECALL_MSG = 'nodeIKernelMsgService/recallMsg',
   SEND_MSG = 'nodeIKernelMsgService/sendMsg',
+  PREPARE_TEMP_CHAT = "nodeIKernelMsgService/prepareTempChat",
   EMOJI_LIKE = 'nodeIKernelMsgService/setMsgEmojiLikes',
 
   DOWNLOAD_MEDIA = 'nodeIKernelMsgService/downloadRichMedia',


### PR DESCRIPTION
似乎在发起临时会话前没有进行准备工作。经过测试，必须在发送一个准备的信号后，私聊消息才能正常发出。否则只是看似正常发出了，接收方并没有办法真正看到临时会话的消息，而且连续多次尝试还会被风控，甚至是封号。也许是tx为了制裁协议端做的一个限制？

已经补齐该功能，测试正常，好久没碰LLOneBot代码了，代码风格可能与要求有差异，如有修改需求，请向我提出。