### PR TITLE
downloadMedia下载文件超时时间修改为30分钟

### DIFF
--- a/src/ntqqapi/api/file.ts
+++ b/src/ntqqapi/api/file.ts
@@ -100,7 +100,7 @@ export class NTQQFileApi extends Service {
     elementId: string,
     thumbPath = '',
     sourcePath = '',
-    timeout = 1000 * 60 * 2,
+    timeout = 1000 * 60 * 30,
     force = false
   ) {
     // 用于下载收到的消息中的图片等


### PR DESCRIPTION
大文件下载超时，导致接口未获得正常响应，但实际上文件最终还是被正常下载的，为了解决大文件如1G以上文件下载超时问题，调大超时。 解决问题：ntqq api timeout IPC_UP_2, ns-ntApi-2, nodeIKernelMsgService/downloadRichMedia, [{"getReq":{"fileModelId":"0","downloadSourceType":0,"triggerType":1,"msgId":"7448814490483661075","chatType":2,"peerUid":"960581870","elementId":"7448814490483661074","thumbSize":0,"downloadType":1,"filePath":""}}],200

## Summary by Sourcery

错误修复：
- 将 `downloadMedia` 函数的超时时间增加到 30 分钟，以防止大文件下载时出现超时问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the timeout for the downloadMedia function to 30 minutes to prevent timeout issues with large file downloads.

</details>