### PR TITLE
fix

### DIFF
--- a/src/ntqqapi/ntcall.ts
+++ b/src/ntqqapi/ntcall.ts
@@ -142,13 +142,17 @@ export function invoke<
       return
     }
     let eventName = className + '-' + channel[channel.length - 1]
+    let apiArgs: unknown[] | { cmdName: string, cmdType: 'invoke', payload: unknown[] } | string = [method, ...args]
+    if (getBuildVersion() >= 32690) {
+      eventName = className.split('-')[1]
+      if (options.registerEvent) {
+        apiArgs = method
+      } else {
+        apiArgs = { cmdName: method, cmdType: 'invoke', payload: args }
+      }
+    }
     if (options.registerEvent) {
       eventName += '-register'
-    }
-    let apiArgs: unknown[] | { cmdName: string, cmdType: 'invoke', payload: unknown[] } = [method, ...args]
-    if (getBuildVersion() >= 32609) {
-      eventName = className.split('-')[1]
-      apiArgs = { cmdName: method, cmdType: 'invoke', payload: args }
     }
     const callbackId = randomUUID()
     let eventId: string
@@ -212,7 +216,7 @@ export function invoke<
           },
         },
       },
-      { type: 'request', callbackId, eventName, peerId: channel.slice(-1) },
+      { type: 'request', callbackId, eventName, peerId: Number(channel.slice(-1)) },
       apiArgs,
     )
   })


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

调整 `invoke` 函数以处理不同构建版本的 NTQQ API 变更，包括事件名称、参数结构和对等 ID 类型的调整。

增强功能：

- 调整 `invoke` 函数以处理不同构建版本的 NTQQ API 变更。
- 根据构建版本调整事件名称。
- 修改 API 参数的结构以适应不同的构建版本。
- 将对等 ID 类型更改为数字。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt the invoke function to handle changes in the NTQQ API for different build versions, including adjustments to event names, argument structures, and peer ID types.

Enhancements:
- Adapt the invoke function to handle changes in the NTQQ API for different build versions.
- Adjust event names based on the build version.
- Modify the structure of API arguments to accommodate different build versions.
- Change the peer ID type to a number.

</details>