### PR TITLE
feat: 添加 satori API扩展 和 send_poke

### DIFF
--- a/src/onebot11/action/llonebot/SendPoke.ts
+++ b/src/onebot11/action/llonebot/SendPoke.ts
@@ -1,0 +1,28 @@
+import { group } from 'console'
+import { BaseAction, Schema } from '../BaseAction'
+import { ActionName } from '../types'
+import { getBuildVersion } from '@/common/utils'
+
+interface Payload {
+  group_id: number | string
+  user_id: number | string
+}
+
+export class GroupPoke extends BaseAction<Payload, null> {
+  actionName = ActionName.SendPoke
+  payloadSchema = Schema.object({
+    group_id: Schema.union([Number, String]),
+    user_id: Schema.union([Number, String]).required()
+  })
+
+  async _handle(payload: Payload) {
+    if (!this.ctx.app.native.checkPlatform() || !this.ctx.app.native.checkVersion()) {
+      throw new Error('戳一戳暂时只支持Windows QQ 27333 ~ 275970版本')
+    } else if (payload.group_id === undefined) {
+      await this.ctx.app.native.sendFriendPoke(+payload.user_id)
+    } else{
+      await this.ctx.app.native.sendGroupPoke(+payload.group_id, +payload.user_id)
+    }
+    return null
+  }
+}

--- a/src/onebot11/action/types.ts
+++ b/src/onebot11/action/types.ts
@@ -11,6 +11,7 @@ export interface InvalidCheckResult {
 
 export enum ActionName {
   // llonebot
+  SendPoke = 'send_poke',
   GetGroupIgnoreAddRequest = 'get_group_ignore_add_request',
   SetQQAvatar = 'set_qq_avatar',
   GetConfig = 'get_config',


### PR DESCRIPTION
## Sourcery 总结

新功能：
- 添加了 "send_poke" 操作到 OneBot 11 API，允许机器人向群组或好友中的用户发送戳一戳消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Adds the "send_poke" action to the OneBot 11 API, allowing the bot to send poke messages to users in groups or as friends.

</details>