### PR TITLE
Potential fix for code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/src/onebot11/helper/eventForHttp.ts
+++ b/src/onebot11/helper/eventForHttp.ts
@@ -29,6 +29,9 @@ export function postHttpEvent(event: PostEventType) {
 }
 
 export async function getHttpEvent(userKey: string, timeout = 0) {
+  if (userKey === '__proto__' || userKey === 'constructor' || userKey === 'prototype') {
+    throw new Error('Invalid user key');
+  }
   const toRetEvent: PostEventType[] = []
 
   // 清除过时的user，5分钟没访问过的user将被删除

--- a/src/onebot11/helper/eventForHttp.ts
+++ b/src/onebot11/helper/eventForHttp.ts
@@ -29,7 +29,7 @@ export function postHttpEvent(event: PostEventType) {
 }
 
 export async function getHttpEvent(userKey: string, timeout = 0) {
-  if (userKey === '__proto__' || userKey === 'constructor' || userKey === 'prototype') {
+  if (typeof userKey !== 'string' || userKey === '__proto__' || userKey === 'constructor' || userKey === 'prototype') {
     throw new Error('Invalid user key');
   }
   const toRetEvent: PostEventType[] = []


### PR DESCRIPTION
Potential fix for [https://github.com/LLOneBot/LLOneBot/security/code-scanning/9](https://github.com/LLOneBot/LLOneBot/security/code-scanning/9)

To fix the problem, we need to ensure that the `userKey` cannot be a value that would lead to prototype pollution. This can be achieved by validating the `userKey` before using it as a key in the `httpUser` object. We will reject keys that are `__proto__`, `constructor`, or `prototype`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复：
- 阻止潜在的原型污染，方法是拒绝用户输入中特定的 JavaScript 保留对象键名（'__proto__'、'constructor'、'prototype'）

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

Bug 修复：
- 添加输入验证以拒绝可能导致 JavaScript 中原型污染的潜在危险对象键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add input validation to reject potentially dangerous object keys that could lead to prototype pollution in JavaScript

</details>

</details>