### PR TITLE
feat: 转发群/私聊单条消息接口支持长消息id

### DIFF
--- a/src/onebot11/action/llonebot/ForwardSingleMsg.ts
+++ b/src/onebot11/action/llonebot/ForwardSingleMsg.ts
@@ -6,6 +6,7 @@ interface Payload {
   message_id: number | string
   group_id: number | string
   user_id?: number | string
+  is_long_id?: boolean
 }
 
 interface Response {
@@ -14,8 +15,16 @@ interface Response {
 
 abstract class ForwardSingleMsg extends BaseAction<Payload, Response> {
   protected async _handle(payload: Payload) {
+    payload.is_long_id = payload.is_long_id ?? false
     if (!payload.message_id) {
       throw Error('message_id不能为空')
+    }
+    if (payload.is_long_id) {
+      const msg = await this.ctx.store.getShortIdByMsgId(String(payload.message_id))
+      if (!msg) {
+        throw Error(`无法找到长id消息${payload.message_id}`)
+      }
+      payload.message_id = msg
     }
     const msg = await this.ctx.store.getMsgInfoByShortId(+payload.message_id)
     if (!msg) {

--- a/src/onebot11/action/llonebot/ForwardSingleMsg.ts
+++ b/src/onebot11/action/llonebot/ForwardSingleMsg.ts
@@ -6,7 +6,6 @@ interface Payload {
   message_id: number | string
   group_id: number | string
   user_id?: number | string
-  is_long_id?: boolean
 }
 
 interface Response {
@@ -15,26 +14,38 @@ interface Response {
 
 abstract class ForwardSingleMsg extends BaseAction<Payload, Response> {
   protected async _handle(payload: Payload) {
-    payload.is_long_id = payload.is_long_id ?? false
+    // 判断为空
     if (!payload.message_id) {
       throw Error('message_id不能为空')
     }
-    if (payload.is_long_id) {
-      const msg = await this.ctx.store.getShortIdByMsgId(String(payload.message_id))
-      if (!msg) {
-        throw Error(`无法找到长id消息${payload.message_id}`)
+
+    // 判断长id
+    if (!(+payload.message_id >= -2147483648 && +payload.message_id <= 2147483647)) {
+      const short_msg_id = await this.ctx.store.getShortIdByMsgId(String(payload.message_id))
+      if (!short_msg_id) {
+        throw new Error(`无法找到长id消息${payload.message_id}`)
       }
-      payload.message_id = msg
+      payload.message_id = short_msg_id
     }
+
+    // 获取源消息判断是否存在
     const msg = await this.ctx.store.getMsgInfoByShortId(+payload.message_id)
     if (!msg) {
       throw new Error(`无法找到消息${payload.message_id}`)
     }
+    
+    // 发送目标的peer
     const peer = await createPeer(this.ctx, payload)
+
+    // 转发消息
     const ret = await this.ctx.ntMsgApi.forwardMsg(msg.peer, peer, [msg.msgId])
+
+    // 判断是否成功
     if (ret.length === 0) {
       throw new Error(`转发消息失败`)
     }
+
+    // 创建消息id
     const msgShortId = this.ctx.store.createMsgShortId({
       chatType: ret[0].chatType,
       peerUid: ret[0].peerUid


### PR DESCRIPTION
## Sourcery 总结

在单消息转发接口中添加了使用长消息 ID 转发消息的支持

新特性：
- 引入了一个可选的 `is_long_id` 参数，用于处理使用长消息标识符转发消息的情况

增强功能：
- 修改了消息转发逻辑，以便在处理之前将长消息 ID 转换为短消息 ID

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for forwarding messages using long message IDs in the single message forwarding interface

New Features:
- Introduce an optional `is_long_id` parameter to handle forwarding of messages using long message identifiers

Enhancements:
- Modify message forwarding logic to convert long message IDs to short message IDs before processing

</details>