### PR TITLE
feat: add send_pb action

### DIFF
--- a/src/ntqqapi/native/pmhq/index.ts
+++ b/src/ntqqapi/native/pmhq/index.ts
@@ -247,8 +247,14 @@ export class PMHQ {
     })).data
   }
 
-  async sendPB(cmd: string, pb: Uint8Array): Promise<PBData> {
-    return this.wsSendPB(cmd,pb)
+  async sendPB(cmd: string, hex: string): Promise<PBData> {
+    return (await this.wsSend<PMHQResSendPB>({
+      type: 'send',
+      data: {
+        cmd,
+        pb: hex,
+      },
+    })).data
   }
 
   async sendFriendPoke(uin: number) {

--- a/src/ntqqapi/native/pmhq/index.ts
+++ b/src/ntqqapi/native/pmhq/index.ts
@@ -247,6 +247,10 @@ export class PMHQ {
     })).data
   }
 
+  async sendPB(cmd: string, pb: Uint8Array): Promise<PBData> {
+    return this.wsSendPB(cmd,pb)
+  }
+
   async sendFriendPoke(uin: number) {
     const body = Oidb.SendPoke.encode({
       toUin: uin,

--- a/src/onebot11/action/index.ts
+++ b/src/onebot11/action/index.ts
@@ -92,12 +92,12 @@ import { MoveGroupFile } from './llonebot/MoveGroupFile'
 import { GetGroupShutList } from './llonebot/GetGroupShutList'
 import { RenameGroupFileFolder } from './llonebot/RenameGroupFileFolder'
 import { VoiceMsg2Text } from '@/onebot11/action/llonebot/VoiceMsg2Text'
-import { SendRaw } from './llonebot/SendRaw'
+import { SendPB } from './llonebot/SendPB'
 
 export function initActionMap(adapter: Adapter) {
   const actionHandlers = [
     // llonebot
-    new SendRaw(adapter),
+    new SendPB(adapter),
     new VoiceMsg2Text(adapter),
     new GetFile(adapter),
     new Debug(adapter),

--- a/src/onebot11/action/index.ts
+++ b/src/onebot11/action/index.ts
@@ -92,10 +92,12 @@ import { MoveGroupFile } from './llonebot/MoveGroupFile'
 import { GetGroupShutList } from './llonebot/GetGroupShutList'
 import { RenameGroupFileFolder } from './llonebot/RenameGroupFileFolder'
 import { VoiceMsg2Text } from '@/onebot11/action/llonebot/VoiceMsg2Text'
+import { SendRaw } from './llonebot/SendRaw'
 
 export function initActionMap(adapter: Adapter) {
   const actionHandlers = [
     // llonebot
+    new SendRaw(adapter),
     new VoiceMsg2Text(adapter),
     new GetFile(adapter),
     new Debug(adapter),

--- a/src/onebot11/action/llonebot/SendPB.ts
+++ b/src/onebot11/action/llonebot/SendPB.ts
@@ -12,8 +12,8 @@ interface PBData{
   echo?: string
 }
 
-export class SendRaw extends BaseAction<Payload, PBData> {
-  actionName = ActionName.SendRaw
+export class SendPB extends BaseAction<Payload, PBData> {
+  actionName = ActionName.SendPB
   payloadSchema = Schema.object({
     cmd: String,
     hex: String
@@ -21,7 +21,7 @@ export class SendRaw extends BaseAction<Payload, PBData> {
 
   async _handle(payload: Payload) {
     try {
-      const result = await this.ctx.app.pmhq.sendPB(payload.cmd, Uint8Array.from(Buffer.from(payload.hex, 'hex')))
+      const result = await this.ctx.app.pmhq.sendPB(payload.cmd, payload.hex)
       return {
         cmd: result.cmd,
         hex: result.pb,
@@ -30,7 +30,7 @@ export class SendRaw extends BaseAction<Payload, PBData> {
     }
     catch (e) {
       this.ctx.logger.error('pmhq 发包失败', e)
-      throw new Error(`pmhq 发包失败: ${e}`)
+      throw new Error(`pmhq 发包失败: ${e}`, { cause: e })
     }
   }
 }

--- a/src/onebot11/action/llonebot/SendRaw.ts
+++ b/src/onebot11/action/llonebot/SendRaw.ts
@@ -1,0 +1,36 @@
+import { from } from '@satorijs/element'
+import { BaseAction, Schema } from '../BaseAction'
+import { ActionName } from '../types'
+
+interface Payload {
+  cmd: string
+  hex: string
+}
+interface PBData{
+  cmd: string
+  hex: string
+  echo?: string
+}
+
+export class SendRaw extends BaseAction<Payload, PBData> {
+  actionName = ActionName.SendRaw
+  payloadSchema = Schema.object({
+    cmd: String,
+    hex: String
+  })
+
+  async _handle(payload: Payload) {
+    try {
+      const result = await this.ctx.app.pmhq.sendPB(payload.cmd, Uint8Array.from(Buffer.from(payload.hex, 'hex')))
+      return {
+        cmd: result.cmd,
+        hex: result.pb,
+        ...(result.echo !== undefined ? { echo: result.echo } : {})
+      }
+    }
+    catch (e) {
+      this.ctx.logger.error('pmhq 发包失败', e)
+      throw new Error(`pmhq 发包失败: ${e}`)
+    }
+  }
+}

--- a/src/onebot11/action/types.ts
+++ b/src/onebot11/action/types.ts
@@ -11,6 +11,7 @@ export interface InvalidCheckResult {
 
 export enum ActionName {
   // llonebot
+  SendRaw = "send_raw",
   VoiceMsg2Text = 'voice_msg_to_text',
   SendPoke = 'send_poke',
   GetGroupIgnoreAddRequest = 'get_group_ignore_add_request',

--- a/src/onebot11/action/types.ts
+++ b/src/onebot11/action/types.ts
@@ -11,7 +11,7 @@ export interface InvalidCheckResult {
 
 export enum ActionName {
   // llonebot
-  SendRaw = "send_raw",
+  SendPB = "send_pb",
   VoiceMsg2Text = 'voice_msg_to_text',
   SendPoke = 'send_poke',
   GetGroupIgnoreAddRequest = 'get_group_ignore_add_request',


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

添加对新的 `send_raw` OneBot 操作的支持，该操作通过 PMHQ 转发任意 protobuf 命令。

新功能：
- 实现 `SendRaw` 操作以通过 OneBot 发送原始 protobuf 负载
- 添加 `PMHQ.sendPB` 方法作为 `wsSendPB` 的包装器

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a new send_raw OneBot action that forwards arbitrary protobuf commands through PMHQ.

New Features:
- Implement SendRaw action to send raw protobuf payloads via OneBot
- Add PMHQ.sendPB method as a wrapper for wsSendPB

</details>