### PR TITLE
fix: GetMsg returns group_name when message's type is Group.

### DIFF
--- a/src/onebot11/entities.ts
+++ b/src/onebot11/entities.ts
@@ -89,6 +89,7 @@ export namespace OB11Entities {
     if (msg.chatType === ChatType.Group) {
       resMsg.sub_type = 'normal'
       resMsg.group_id = parseInt(msg.peerUin)
+      resMsg.group_name = msg.peerName
       // 284840486: 合并转发内部
       if (msg.peerUin !== '284840486') {
         try {

--- a/src/onebot11/types.ts
+++ b/src/onebot11/types.ts
@@ -85,6 +85,7 @@ export interface OB11Message {
   real_id?: number // 仅在 get_msg 接口存在
   user_id: number
   group_id?: number
+  group_name?: string
   message_type: 'private' | 'group'
   sub_type?: 'friend' | 'group' | 'normal'
   sender: OB11Sender


### PR DESCRIPTION
GetMsg返回群消息时没有返回群名，本修改增加了此信息的返回。
方便做日志记录，展示信息…

## Sourcery 总结

错误修复：
- 在群聊返回的消息对象中包含 group_name。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include group_name in returned message object for group chats.

</details>