### PR TITLE
fix: 修复docker启动脚本中 pmhq_host 环境变量被错误赋值给 port 的问题

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -57,6 +57,6 @@ if [ -n "$pmhq_port" ]; then
   port="$pmhq_port"
 fi
 if [ -n "$pmhq_host" ]; then
-  port="$pmhq_host"
+  host="$pmhq_host"
 fi
 node ./llonebot.js --pmhq-port=$port --pmhq-host=$host


### PR DESCRIPTION
## Sourcery 总结

错误修复:
- 修正 startup.sh 中 pmhq_host 环境变量赋值为 host 而非 port 的问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct pmhq_host environment variable assignment to host instead of port in startup.sh

</details>