### PR TITLE
fix: (webui) prevent background animations from blocking the main content

### DIFF
--- a/src/webui/FE/App.tsx
+++ b/src/webui/FE/App.tsx
@@ -157,7 +157,7 @@ function App() {
 
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} accountInfo={accountInfo || undefined} />
 
-      <main className="flex-1 p-8 overflow-auto">
+      <main className="flex-1 p-8 overflow-auto" style={{ zIndex: 1 }}>
         <div className="max-w-6xl mx-auto">
           {/* Header */}
           <div className="mb-8">


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the main content area of the web application. The change adds a `zIndex` style to the `<main>` element to ensure proper stacking order in the interface.

* UI enhancement: Added an inline style `{ zIndex: 1 }` to the `<main>` element in `src/webui/FE/App.tsx` to address stacking context issues.

## Sourcery 总结

错误修复：
- 通过为 `<main>` 元素添加 z-index 样式，防止背景动画阻挡主要内容

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent background animations from blocking main content by adding a z-index style to the <main> element

</details>