### PR TITLE
fix:http api get_event

### DIFF
--- a/src/onebot11/adapter.ts
+++ b/src/onebot11/adapter.ts
@@ -18,8 +18,6 @@ import { Config as LLOBConfig, OB11Config } from '../common/types'
 import { OB11WebSocket, OB11WebSocketReverse } from './connect/ws'
 import { OB11Http, OB11HttpPost } from './connect/http'
 import { OB11BaseEvent } from './event/OB11BaseEvent'
-import { OB11BaseMetaEvent } from './event/meta/OB11BaseMetaEvent'
-import { postHttpEvent } from './helper/eventForHttp'
 import { initActionMap } from './action'
 import { OB11GroupAdminNoticeEvent } from './event/notice/OB11GroupAdminNoticeEvent'
 import { OB11ProfileLikeEvent } from './event/notice/OB11ProfileLikeEvent'
@@ -89,10 +87,6 @@ class OneBot11Adapter extends Service {
   public dispatch(event: OB11BaseEvent) {
     for (const item of this.connect) {
       item.emitEvent(event)
-    }
-    if ((event as OB11BaseMetaEvent).meta_event_type !== 'heartbeat') {
-      // 不上报心跳
-      postHttpEvent(event)
     }
   }
 

--- a/src/onebot11/connect/http.ts
+++ b/src/onebot11/connect/http.ts
@@ -13,6 +13,7 @@ import { OB11HeartbeatEvent } from '../event/meta/OB11HeartbeatEvent'
 import { Dict } from 'cosmokit'
 import { HttpConnectConfig, HttpPostConnectConfig } from '@/common/types'
 import { OB11Message } from '../types'
+import { postHttpEvent } from '../helper/eventForHttp'
 
 class OB11Http {
   private readonly expressAPP: Express
@@ -124,6 +125,7 @@ class OB11Http {
   }
 
   public async emitEvent(event: OB11BaseEvent) {
+    postHttpEvent(event)
     if (!this.activated) return
     if (this.sseClients.length === 0) {
       return


### PR DESCRIPTION
## Summary by Sourcery

增强:
- 将 HTTP 事件发送从 OneBot11 适配器移动到 HTTP 连接类中，以集中管理事件触发逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Move HTTP event posting from the OneBot11 adapter into the HTTP connection class to centralize event emission logic.

</details>