### PR TITLE
fix: enhance WebSocket access token validation method

### DIFF
--- a/src/milky/network/http.ts
+++ b/src/milky/network/http.ts
@@ -92,8 +92,8 @@ class MilkyHttpHandler {
 
         let inputToken = ''
         const authHeader = req.headers['authorization']
-        if (authHeader) {
-          inputToken = authHeader.split('Bearer ').pop()!
+        if (authHeader?.toLowerCase().startsWith('bearer ')) {
+          inputToken = authHeader.slice(7).trim()
           this.ctx.logger.info('receive ws header token', inputToken)
         } else {
           inputToken = url.searchParams.get('access_token') ?? ''


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 允许通过 `Authorization` Bearer 头（header）来提供 WebSocket 访问令牌（access token），此外仍支持通过 `access_token` 查询参数提供。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow WebSocket access tokens to be provided via the Authorization bearer header in addition to the access_token query parameter.

</details>