### PR TITLE
Add shebang to start-linux.sh script

### DIFF
--- a/script/start-linux.sh
+++ b/script/start-linux.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # 检测是否为 Debian 系列系统（通过 apt 命令）


### PR DESCRIPTION
指定系统使用bash执行，使用chmod +x start.sh && ./start.sh，会使用用户shell

## Summary by Sourcery

增强功能：
- 通过添加 shebang 行，确保 Linux 启动脚本显式使用 Bash，从而在不同环境中保持一致的执行行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Ensure the Linux start script explicitly uses Bash by adding a shebang line for consistent execution across environments.

</details>