### PR TITLE
fix(milky): friend_nudge user_id is zero

### DIFF
--- a/src/milky/transform/event.ts
+++ b/src/milky/transform/event.ts
@@ -203,10 +203,11 @@ export async function transformPrivateMessageEvent(
     for (const element of message.elements) {
       if (element.grayTipElement?.jsonGrayTipElement?.busiId === '1061') {
         const { templParam } = element.grayTipElement.jsonGrayTipElement.xmlToJsonParam
+        const userId = +message.peerUin || +(await ctx.ntUserApi.getUinByUid(message.peerUid))
         return {
           eventType: 'friend_nudge',
           data: {
-            user_id: +message.peerUin,
+            user_id: userId,
             is_self_send: templParam.get('uin_str1') === selfInfo.uin,
             is_self_receive: templParam.get('uin_str2') === selfInfo.uin,
             display_action: templParam.get('action_str'),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保在缺少 `peerUin` 或其值为 0 时，`friend_nudge` 事件会回退为通过 `peerUid` 解析 `user_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure friend_nudge events fall back to resolving user_id from peerUid when peerUin is missing or zero.

</details>