### PR TITLE
feat: 本地项目 docker 构建支持

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,0 +1,38 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare yarn@4.12.0 --activate
+
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
+
+RUN yarn install --immutable
+
+COPY src/webui/FE/package.json src/webui/FE/
+RUN cd src/webui/FE && npm install
+
+COPY . .
+
+RUN yarn build-webui
+
+RUN yarn build
+
+
+FROM node:22-alpine AS production
+
+RUN set -eux; \
+    apk update; \
+    apk add --no-cache tzdata ffmpeg; \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime; \
+    echo "Asia/Shanghai" > /etc/timezone; \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /app/llbot
+
+COPY --from=builder /app/dist .
+
+COPY docker/startup.sh /startup.sh
+RUN chmod +x /startup.sh
+
+ENTRYPOINT ["/startup.sh"]


### PR DESCRIPTION
增加了本地构建项目而不是下载预构建好的包的 Dockerfile

## Summary by Sourcery

Build:
- 引入本地 Dockerfile 配置，以支持直接从本地项目代码库构建镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Introduce a local Dockerfile configuration to support building images directly from the local project codebase.

</details>