### PR TITLE
feat: onebot 自定义合并转发外显和嵌套合并转发支持

### DIFF
--- a/src/onebot11/types.ts
+++ b/src/onebot11/types.ts
@@ -378,6 +378,11 @@ export interface OB11PostSendMsg {
   group_id?: string | number
   message: OB11MessageMixType
   auto_escape?: boolean
+  // 合并转发自定义外显
+  source?: string
+  news?: { text: string }[]
+  summary?: string
+  prompt?: string
 }
 
 export interface OB11Version {


### PR DESCRIPTION
拆分的 #678
API 是和 napcat 兼容的

## Summary by Sourcery

在保持与现有转发行为兼容的前提下，为 OneBot v11 实现添加对「可自定义」和「嵌套」合并转发消息的支持。

新功能：
- 允许调用方通过 OneBot 发送接口中的可选 `source`、`news`、`summary` 和 `prompt` 字段，自定义合并转发消息的外观。
- 在构建合并转发负载时，支持具有最大嵌套层级限制的嵌套转发和节点消息。

增强改进：
- 扩展 `MessageEncoder` 和转发消息处理逻辑，使其同时适用于既有的转发 ID 和动态构建的转发内容，并对空负载进行更安全的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for customizable and nested merged-forward messages in the OneBot v11 implementation while preserving compatibility with existing forward behavior.

New Features:
- Allow callers to customize merged-forward message appearance via optional source, news, summary, and prompt fields in OneBot send APIs.
- Support nested forward and node messages with a bounded maximum nesting depth when constructing merged-forward payloads.

Enhancements:
- Extend the MessageEncoder and forward message handling to work with both pre-existing forward IDs and dynamically built forward contents, including safer handling of empty payloads.

</details>