### PR TITLE
fix(email-config): Do not prompt for email configuration issues when email notifications are disabled

### DIFF
--- a/src/common/emailConfig.ts
+++ b/src/common/emailConfig.ts
@@ -88,6 +88,11 @@ export class EmailConfigManager {
   validateConfig(config: EmailConfig): ValidationResult {
     const errors: string[] = []
 
+    // 关闭邮件通知时允许保存空配置（issue##690）
+    if (!config.enabled) {
+      return { valid: true, errors: [] }
+    }
+
     if (!config.smtp.host || config.smtp.host.trim() === '') {
       errors.push('SMTP 服务器不能为空')
     }


### PR DESCRIPTION
issue: https://github.com/LLOneBot/LuckyLilliaBot/issues/690

## Summary by Sourcery

Bug Fixes:
- 当通知被禁用时，跳过电子邮件配置验证错误，防止用户因 SMTP 设置为空而被阻塞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Skip email configuration validation errors when notifications are disabled, preventing users from being blocked by empty SMTP settings.

</details>