### PR TITLE
feat(script): Auto bind WebUI to 0.0.0.0 in headless mode

### DIFF
--- a/script/start-linux.sh
+++ b/script/start-linux.sh
@@ -21,7 +21,6 @@ check_sudo() {
     sudo -v || error "Sudo 验证失败或被取消，脚本终止。"
 }
 
-
 trap cleanup SIGINT SIGTERM
 
 confirm() {
@@ -30,7 +29,6 @@ confirm() {
     echo ""
     [[ "$key" == "Y" || "$key" == "y" || "$key" == "" ]]
 }
-
 
 # 环境检查
 if command -v pacman &> /dev/null; then
@@ -89,7 +87,6 @@ install_debian() {
 chmod +x "$SCRIPT_DIR/bin/llbot/node" "$SCRIPT_DIR/bin/pmhq/pmhq" "$LLBOT_CLI_BIN" 2>/dev/null
 sudo chown -R $(whoami):$(whoami) "$SCRIPT_DIR/bin" 2>/dev/null
 
-
 echo "------------------------------------------------"
 echo "1) GUI 模式 (有界面)"
 echo "2) Shell 模式 (无界面)"
@@ -138,7 +135,9 @@ run_llbot() {
     log "启动模式: $([ $USE_XVFB -eq 1 ] && echo "Headless" || echo "GUI")"
 
     if [ $USE_XVFB -eq 1 ]; then
-        env $IM_ENV xvfb-run -a "$LLBOT_CLI_BIN"
+        warn "Headless 模式将监听 0.0.0.0，可能暴露服务到公网/内网。"
+        warn "请用防火墙/安全组限制来源，或使用 SSH 隧道再访问。"
+        env $IM_ENV xvfb-run -a "$LLBOT_CLI_BIN" --host=0.0.0.0
     else
         [ "$DISTRO" != "arch" ] && xhost +local:$(whoami) > /dev/null 2>&1
         env $IM_ENV "$LLBOT_CLI_BIN"


### PR DESCRIPTION
## Summary by Sourcery

在无头模式下运行时将 WebUI 绑定到 0.0.0.0，并显示有关潜在暴露风险的安全警告。

新功能：
- 在通过启动脚本以无头（xvfb）模式启动时，将 WebUI 暴露在 0.0.0.0 上。

增强内容：
- 在无头模式下显示清晰的安全警告，提示网络暴露风险，并建议使用防火墙或 SSH 隧道。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bind the WebUI to 0.0.0.0 when running in headless mode and surface security warnings about potential exposure.

New Features:
- Expose the WebUI on 0.0.0.0 when launching in headless (xvfb) mode via the startup script.

Enhancements:
- Display clear security warnings in headless mode about network exposure and recommend firewall or SSH tunnel usage.

</details>