### PR TITLE
fix(milky): 放宽 Content-Type 校验逻辑以支持 charset 参数

### DIFF
--- a/src/milky/network/http.ts
+++ b/src/milky/network/http.ts
@@ -45,7 +45,7 @@ class MilkyHttpHandler {
     // Access token middleware for API routes
     if (this.config.accessToken) {
       this.app.use(`${this.config.prefix}/api`, (req, res, next) => {
-        if (req.headers['content-type'] !== 'application/json') {
+        if (!req.headers['content-type']?.includes('application/json')) {
           this.ctx.logger.warn(
             'MilkyHttp',
             `${req.ip} -> ${req.path} (Content-Type not application/json)`


### PR DESCRIPTION
## 问题描述
当前服务端的中间件在校验 Content-Type 时使用了严格全等判断 (!==)：
```typescript
if (req.headers['content-type'] !== 'application/json') { ... }
```
导致的问题是，一些 HTTP 客户端（如 .NET 的 HttpClient）在发送请求时会自动附加编码信息，将头设置为 application/json; charset=utf-8，从而导致服务端判定为不匹配返回 415

## 修改内容
改成了包含判断
```typescript
if (!req.headers['content-type']?.includes('application/json')) { ... }
```

## Summary by Sourcery

Bug Fixes:
- 允许带有类似 `application/json; charset=utf-8` 这种 Content-Type 头的 API 请求通过校验，而不是返回 415 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow API requests with Content-Type headers like application/json; charset=utf-8 to pass validation instead of being rejected with 415.

</details>