### PR TITLE
feat(onebot): add rename_group_file action

### DIFF
--- a/src/onebot11/action/index.ts
+++ b/src/onebot11/action/index.ts
@@ -90,6 +90,7 @@ import { GetProfileLike } from './llbot/user/GetProfileLike'
 import { GetCsrfToken } from './system/GetCsrfToken'
 import { SetGroupPortrait } from './go-cqhttp/SetGroupPortrait'
 import { MoveGroupFile } from './llbot/file/MoveGroupFile'
+import { RenameGroupFile } from './llbot/file/RenameGroupFile'
 import { GetGroupShutList } from './llbot/group/GetGroupShutList'
 import { RenameGroupFileFolder } from './llbot/file/RenameGroupFileFolder'
 import { VoiceMsg2Text } from '@/onebot11/action/llbot/msg/VoiceMsg2Text'
@@ -155,6 +156,7 @@ export function initActionMap(adapter: Adapter) {
     new SetGroupMsgMask(adapter),
     new SetGroupRemark(adapter),
     new MoveGroupFile(adapter),
+    new RenameGroupFile(adapter),
     new GetGroupShutList(adapter),
     new RenameGroupFileFolder(adapter),
     new GetRecommendFace(adapter),

--- a/src/onebot11/action/llbot/file/RenameGroupFile.ts
+++ b/src/onebot11/action/llbot/file/RenameGroupFile.ts
@@ -1,0 +1,28 @@
+import { BaseAction, Schema } from '../../BaseAction'
+import { ActionName } from '../../types'
+
+interface Payload {
+  group_id: number | string
+  file_id: string
+  current_parent_directory: string
+  new_name: string
+}
+
+export class RenameGroupFile extends BaseAction<Payload, null> {
+  actionName = ActionName.RenameGroupFile
+  payloadSchema = Schema.object({
+    group_id: Schema.union([Number, String]).required(),
+    file_id: Schema.string().required(),
+    current_parent_directory: Schema.string().required(),
+    new_name: Schema.string().required()
+  })
+
+  async _handle(payload: Payload) {
+    const groupId = payload.group_id.toString()
+    const res = await this.ctx.ntGroupApi.renameGroupFile(groupId, payload.file_id, payload.current_parent_directory, payload.new_name)
+    if (res.renameGroupFileResult.result.retCode !== 0) {
+      throw new Error(res.renameGroupFileResult.result.clientWording)
+    }
+    return null
+  }
+}

--- a/src/onebot11/action/types.ts
+++ b/src/onebot11/action/types.ts
@@ -49,6 +49,7 @@ export enum ActionName {
   SetGroupMsgMask = 'set_group_msg_mask',
   SetGroupRemark = 'set_group_remark',
   MoveGroupFile = 'move_group_file',
+  RenameGroupFile = 'rename_group_file',
   SetGroupFileForever = 'set_group_file_forever',
   GetGroupShutList = 'get_group_shut_list',
   RenameGroupFileFolder = 'rename_group_file_folder',


### PR DESCRIPTION
增加 rename_group_file API，对齐 napcat 的行为

LLBot 目前没有修改群文件名称的 API，但是 napcat 有这个 API ~~（是我加的）~~

## Summary

- Add `rename_group_file` OneBot11 action for renaming files in QQ group file system
- The underlying `ntGroupApi.renameGroupFile` API already exists; this PR exposes it as an OneBot action

## Details

**Action name**: `rename_group_file`

**Parameters** (compatible with NapCat):
| Parameter | Type | Description |
|---|---|---|
| `group_id` | number \| string | Group ID |
| `file_id` | string | File ID to rename |
| `current_parent_directory` | string | Current parent folder ID (e.g., `/`) |
| `new_name` | string | New file name |

**Changes**:
- New file: `src/onebot11/action/llbot/file/RenameGroupFile.ts`
- Register action name `RenameGroupFile = 'rename_group_file'` in `ActionName` enum
- Register handler in `initActionMap`

Implementation follows the same pattern as the existing `RenameGroupFileFolder` and `MoveGroupFile` actions.

## Summary by Sourcery

新功能：
- 添加 `rename_group_file` OneBot11 动作用于在群文件系统中重命名文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a rename_group_file OneBot11 action for renaming files within a group’s file system.

</details>