### PR TITLE
fix(docker):pmhq container name conflict

### DIFF
--- a/script/install-llbot-docker.sh
+++ b/script/install-llbot-docker.sh
@@ -375,7 +375,6 @@ cat << EOF > docker-compose.yml
 services:
   pmhq:
     image: ${docker_mirror}linyuchen/pmhq:${PMHQ_TAG}
-    container_name: pmhq
     privileged: true
     environment:
 ${PMHQ_ENV}


### PR DESCRIPTION
当需要创建二个及以上的LuckyLilliaBot容器时 指定pmhq容器名称会报错
<img width="898" height="114" alt="image" src="https://github.com/user-attachments/assets/ca8381b5-939d-4d26-be2f-7a0debae1981" />
此次修改去除了pmhq指定container_name的限制

## Summary by Sourcery

Bug Fixes:
- 通过不再在生成的 docker-compose 配置中对 pmhq 的 `container_name` 使用硬编码，解决容器名称冲突问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve container name conflicts by no longer hardcoding the pmhq container_name in the generated docker-compose configuration.

</details>