### PR TITLE
fix: add prefix to milky sse event path

### DIFF
--- a/src/milky/network/http.ts
+++ b/src/milky/network/http.ts
@@ -92,7 +92,7 @@ class MilkyHttpHandler {
     })
 
     // SSE event endpoint
-    this.app.get('/event', (req, res) => {
+    this.app.get(`${this.config.prefix}/event`, (req, res) => {
       // Check access token for SSE connection
       if (this.config.accessToken) {
         const inputToken = this.extractToken(req.headers, req.query as Record<string, unknown>)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保 SSE `/event` 端点遵守已配置的 HTTP 前缀，以便能够通过正确的路径进行访问。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the SSE /event endpoint respects the configured HTTP prefix so it is accessible under the correct path.

</details>