### PR TITLE
chore: update version to 7.12.6

### DIFF
--- a/doc/更新日志.txt
+++ b/doc/更新日志.txt
@@ -1,3 +1,10 @@
+V7.12.6
+更新时间 2026-04-28
+
+* OneBot 修复 _get_group_notice API 获取不到发给新成员的公告
+* OneBot 支持 _get_group_notice API 获取群公告是否置顶
+
+=================
 V7.12.5
 更新时间 2026-04-27
 

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,1 +1,1 @@
-{"name":"llonebot-dist","version":"7.12.5","type":"module","description":"","main":"llbot.js","author":"linyuchen","repository":{"type":"git","url":"https://github.com/LLOneBot/LuckyLilliaBot"}}
+{"name":"llonebot-dist","version":"7.12.6","type":"module","description":"","main":"llbot.js","author":"linyuchen","repository":{"type":"git","url":"https://github.com/LLOneBot/LuckyLilliaBot"}}

--- a/src/ntqqapi/types/group.ts
+++ b/src/ntqqapi/types/group.ts
@@ -156,41 +156,43 @@ export interface GroupAllInfo {
   isAllowModifyConfGroupName: number
 }
 
+interface GroupBulletinFeed {
+  uin: string
+  feedId: string
+  publishTime: string
+  msg: {
+    text: string
+    textFace: string
+    pics: {
+      id: string
+      width: number
+      height: number
+    }[]
+    title: string
+  }
+  type: number
+  fn: number
+  cn: number
+  vn: number
+  settings: {
+    isShowEditCard: number
+    remindTs: number
+    tipWindowType: number
+    confirmRequired: number
+  }
+  pinned: number
+  readNum: number
+  is_read: number
+  is_all_confirm: number
+}
+
 export interface GroupBulletinListResult {
   groupCode: string
   srvCode: number
   readOnly: number
   role: number
-  inst: unknown[]
-  feeds: {
-    uin: string
-    feedId: string
-    publishTime: string
-    msg: {
-      text: string
-      textFace: string
-      pics: {
-        id: string
-        width: number
-        height: number
-      }[]
-      title: string
-    }
-    type: number
-    fn: number
-    cn: number
-    vn: number
-    settings: {
-      isShowEditCard: number
-      remindTs: number
-      tipWindowType: number
-      confirmRequired: number
-    }
-    pinned: number
-    readNum: number
-    is_read: number
-    is_all_confirm: number
-  }[]
+  inst: GroupBulletinFeed[]
+  feeds: GroupBulletinFeed[]
   groupInfo: {
     groupCode: string
     classId: number

--- a/src/onebot11/action/go-cqhttp/GetGroupNotice.ts
+++ b/src/onebot11/action/go-cqhttp/GetGroupNotice.ts
@@ -21,6 +21,7 @@ interface Notice {
     is_show_edit_card: boolean
     tip_window: boolean
     confirm_required: boolean
+    pinned: boolean
   }
 }
 
@@ -51,7 +52,8 @@ export class GetGroupNotice extends BaseAction<Payload, Notice[]> {
         settings: {
           is_show_edit_card: !!feed.settings.isShowEditCard,
           tip_window: !feed.settings.tipWindowType,
-          confirm_required: !!feed.settings.confirmRequired
+          confirm_required: !!feed.settings.confirmRequired,
+          pinned: !!feed.pinned
         }
       })
     }

--- a/src/onebot11/action/go-cqhttp/GetGroupNotice.ts
+++ b/src/onebot11/action/go-cqhttp/GetGroupNotice.ts
@@ -33,7 +33,7 @@ export class GetGroupNotice extends BaseAction<Payload, Notice[]> {
   protected async _handle(payload: Payload) {
     const data = await this.ctx.ntGroupApi.getGroupBulletinList(payload.group_id.toString())
     const result: Notice[] = []
-    for (const feed of data.feeds) {
+    for (const feed of [...data.feeds, ...data.inst]) {
       result.push({
         notice_id: feed.feedId,
         sender_id: +feed.uin,
@@ -54,6 +54,9 @@ export class GetGroupNotice extends BaseAction<Payload, Notice[]> {
           confirm_required: !!feed.settings.confirmRequired
         }
       })
+    }
+    if (data.inst.length > 0) {
+      return result.sort((a, b) => b.publish_time - a.publish_time)
     }
     return result
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '7.12.5'
+export const version = '7.12.6'


### PR DESCRIPTION
## Summary by Sourcery

更新群公告处理逻辑并提升项目版本。

New Features:
- 在群公告响应中暴露公告置顶状态。
- 返回群公告时，同时包含普通群公告和即时群公告。

Enhancements:
- 通过引入可复用的 `GroupBulletinFeed` 接口重构群公告类型。
- 当存在即时公告时，按发布时间对群公告进行排序。
- 将导出的应用版本提升至 `7.12.6`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update group bulletin handling and bump the project version.

New Features:
- Expose bulletin pin status in group notice responses.
- Include both regular and instant group bulletins when returning group notices.

Enhancements:
- Refactor group bulletin types by introducing a reusable GroupBulletinFeed interface.
- Sort group notices by publish time when instant bulletins are present.
- Bump the exported application version to 7.12.6.

</details>