### PR TITLE
chore: update version to 7.12.9

### DIFF
--- a/doc/更新日志.txt
+++ b/doc/更新日志.txt
@@ -1,3 +1,10 @@
+V7.12.9
+更新时间 2026-04-29
+
+* OneBot 修复 get_group_member_info API 可能获取不到性别与年龄
+* OneBot 支持 get_stranger_info API 获取是否会员、是否年费会员、会员等级、备注
+
+=================
 V7.12.8
 更新时间 2026-04-28
 

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,1 +1,1 @@
-{"name":"llonebot-dist","version":"7.12.8","type":"module","description":"","main":"llbot.js","author":"linyuchen","repository":{"type":"git","url":"https://github.com/LLOneBot/LuckyLilliaBot"}}
+{"name":"llonebot-dist","version":"7.12.9","type":"module","description":"","main":"llbot.js","author":"linyuchen","repository":{"type":"git","url":"https://github.com/LLOneBot/LuckyLilliaBot"}}

--- a/src/main/pmhq/mixins/user.ts
+++ b/src/main/pmhq/mixins/user.ts
@@ -12,6 +12,7 @@ export function UserMixin<T extends new (...args: any[]) => PMHQBase>(Base: T) {
           { key: 103 },  // 备注
           { key: 104 },  // 标签
           { key: 105 },  // 等级
+          { key: 107 },  // 业务列表
           { key: 20002 },  // 昵称
           { key: 20003 },  // 国家
           { key: 20009 },  // 性别
@@ -34,6 +35,7 @@ export function UserMixin<T extends new (...args: any[]) => PMHQBase>(Base: T) {
       const info = Oidb.FetchUserInfoResp.decode(oidbRespBody)
       const numbers = Object.fromEntries(info.body.properties.numberProperties.map(p => [p.key, p.value]))
       const bytes = Object.fromEntries(info.body.properties.bytesProperties.map(p => [p.key, p.value]))
+      const business = bytes[107] ? Misc.UserInfoBusiness.decode(bytes[107]) : undefined
       return {
         uin: info.body.uin,
         nick: bytes[20002]?.toString() ?? '',
@@ -51,6 +53,9 @@ export function UserMixin<T extends new (...args: any[]) => PMHQBase>(Base: T) {
         labels: bytes[104] ? Misc.UserInfoLabel.decode(bytes[104]).labels.map(e => e.content) : [],
         school: bytes[20021]?.toString() ?? '',
         remark: bytes[103]?.toString() ?? '',
+        isVip: !!business?.body.lists[0],
+        isYearsVip: !!business?.body.lists[0]?.isYear,
+        vipLevel: business?.body.lists[0]?.level ?? 0
       }
     }
 

--- a/src/main/pmhq/mixins/user.ts
+++ b/src/main/pmhq/mixins/user.ts
@@ -9,12 +9,14 @@ export function UserMixin<T extends new (...args: any[]) => PMHQBase>(Base: T) {
         uin,
         keys: [
           { key: 102 },  // 个性签名
+          { key: 103 },  // 备注
           { key: 104 },  // 标签
           { key: 105 },  // 等级
           { key: 20002 },  // 昵称
           { key: 20003 },  // 国家
           { key: 20009 },  // 性别
           { key: 20020 },  // 城市
+          { key: 20021 },  // 学校
           { key: 20026 },  // 注册时间
           { key: 20031 },  // 生日
           { key: 20037 },  // 年龄
@@ -47,6 +49,8 @@ export function UserMixin<T extends new (...args: any[]) => PMHQBase>(Base: T) {
         birthdayMonth: bytes[20031]?.[2] ?? 0,
         birthdayDay: bytes[20031]?.[3] ?? 0,
         labels: bytes[104] ? Misc.UserInfoLabel.decode(bytes[104]).labels.map(e => e.content) : [],
+        school: bytes[20021]?.toString() ?? '',
+        remark: bytes[103]?.toString() ?? '',
       }
     }
 

--- a/src/milky/api/system.ts
+++ b/src/milky/api/system.ts
@@ -80,29 +80,19 @@ const GetUserProfile = defineApi(
   GetUserProfileInput,
   GetUserProfileOutput,
   async (ctx, payload) => {
-    const userInfo = await ctx.ntUserApi.getUserDetailInfoByUin(payload.user_id.toString())
-    if (userInfo.result !== 0) {
-      return Failed(-500, userInfo.errMsg)
-    }
-    const profile = {
-      nickname: userInfo.detail.simpleInfo.coreInfo.nick,
-      qid: userInfo.detail.simpleInfo.baseInfo.qid,
-      age: userInfo.detail.simpleInfo.baseInfo.age,
-      sex: transformGender(userInfo.detail.simpleInfo.baseInfo.sex),
-      remark: userInfo.detail.simpleInfo.coreInfo.remark,
-      bio: userInfo.detail.simpleInfo.baseInfo.longNick,
-      level: userInfo.detail.commonExt?.qqLevel ?
-        (userInfo.detail.commonExt.qqLevel.penguinNum * 256 + userInfo.detail.commonExt.qqLevel.crownNum * 64 +
-          userInfo.detail.commonExt.qqLevel.sunNum * 16 + userInfo.detail.commonExt.qqLevel.moonNum * 4 +
-          userInfo.detail.commonExt.qqLevel.starNum) : 0,
-      country: userInfo.detail.commonExt?.country || '',
-      city: userInfo.detail.commonExt?.city || '',
-      school: userInfo.detail.commonExt?.college || '',
-    }
-    if (profile.level === 0) {
-      profile.level = (await ctx.pmhq.fetchUserInfo(payload.user_id)).level
-    }
-    return Ok(profile)
+    const info = await ctx.pmhq.fetchUserInfo(payload.user_id)
+    return Ok({
+      nickname: info.nick,
+      qid: info.qid,
+      age: info.age,
+      sex: transformGender(info.sex),
+      remark: info.remark,
+      bio: info.longNick,
+      level: info.level,
+      country: info.country,
+      city: info.city,
+      school: info.school,
+    })
   }
 )
 

--- a/src/ntqqapi/proto/misc.ts
+++ b/src/ntqqapi/proto/misc.ts
@@ -6,4 +6,19 @@ export namespace Misc {
       content: ProtoField(4, 'string')
     }, 'repeated')
   })
+
+  export const UserInfoBusiness = ProtoMessage.of({
+    body: ProtoField(3, {
+      msg: ProtoField(1, 'string'),
+      lists: ProtoField(3, {
+        type: ProtoField(1, 'uint32'),
+        field2: ProtoField(2, 'uint32'),
+        isYear: ProtoField(3, 'uint32'),
+        level: ProtoField(4, 'uint32'),
+        isPro: ProtoField(5, 'uint32'),
+        icon1: ProtoField(6, 'string'),
+        icon2: ProtoField(7, 'string')
+      }, 'repeated')
+    })
+  })
 }

--- a/src/onebot11/action/go-cqhttp/GetStrangerInfo.ts
+++ b/src/onebot11/action/go-cqhttp/GetStrangerInfo.ts
@@ -16,6 +16,10 @@ interface Response extends OB11User {
   city: string
   country: string
   labels: string[]
+  is_vip: boolean
+  is_years_vip: boolean
+  vip_level: number
+  remark: string
 }
 
 export class GetStrangerInfo extends BaseAction<Payload, Response> {
@@ -43,7 +47,11 @@ export class GetStrangerInfo extends BaseAction<Payload, Response> {
       birthday_year: info.birthdayYear,
       birthday_month: info.birthdayMonth,
       birthday_day: info.birthdayDay,
-      labels: info.labels
+      labels: info.labels,
+      is_vip: info.isVip,
+      is_years_vip: info.isYearsVip,
+      vip_level: info.vipLevel,
+      remark: info.remark
     }
   }
 }

--- a/src/onebot11/action/group/GetGroupMemberInfo.ts
+++ b/src/onebot11/action/group/GetGroupMemberInfo.ts
@@ -28,23 +28,25 @@ class GetGroupMemberInfo extends BaseAction<Payload, OB11GroupMember> {
     let info: UserDetailInfo | undefined
     try {
       info = await this.ctx.ntUserApi.getUserDetailInfoWithBizInfo(member.uid)
-      this.ctx.logger.info('getUserDetailInfoWithBizInfo')
     } catch (e) {
       try {
         const fetchInfo = await this.ctx.ntUserApi.fetchUserDetailInfo(member.uid)
         info = fetchInfo.detail.get(member.uid)
-        this.ctx.logger.info('fetchUserDetailInfo')
       } catch (e) {
       }
     }
-    if (info) {
-      this.ctx.logger.info(info)
+    if (info?.commonExt) {
       ret.sex = OB11Entities.sex(info.simpleInfo.baseInfo.sex)
-      ret.qq_level = info.commonExt?.qqLevel && calcQQLevel(info.commonExt.qqLevel) || 0
-      ret.age = info.simpleInfo.baseInfo.age ?? 0
-    }
-    if (ret.qq_level === 0) {
-      ret.qq_level = (await this.ctx.pmhq.fetchUserInfo(+payload.user_id)).level
+      ret.qq_level = calcQQLevel(info.commonExt.qqLevel)
+      ret.age = info.simpleInfo.baseInfo.age
+      if (ret.qq_level === 0) {
+        ret.qq_level = (await this.ctx.pmhq.fetchUserInfo(+payload.user_id)).level
+      }
+    } else {
+      const info = await this.ctx.pmhq.fetchUserInfo(+payload.user_id)
+      ret.sex = OB11Entities.sex(info.sex)
+      ret.qq_level = info.level
+      ret.age = info.age
     }
     return ret
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '7.12.8'
+export const version = '7.12.9'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,13 +1596,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.5.10":
-  version: 8.5.10
-  resolution: "postcss@npm:8.5.10"
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/c592dffa0c4873b401f01955b265538d9942f425040df5e2b8f0ad34c83773a792ea0fa5859ccc99cfb5b955b4ebff118ab7056315388dc83b107b0fa8313576
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary by Sourcery

简化用户资料获取逻辑，改为依赖 PMHQ 用户信息服务，并在各类 API 中扩展对外暴露的用户元数据，同时提升项目版本。

New Features:
- 在 go-cqhttp 陌生人信息 API 响应中暴露 VIP 状态、VIP 等级和备注字段。
- 在基于 PMHQ 服务的用户资料响应中包含更多用户元数据，如学校和备注信息。

Enhancements:
- 当 NT 用户详情查询失败或缺少群成员常用扩展字段时，回退到 PMHQ 用户信息，以确保数据获取更加健壮。
- 在共享的用户 mixin 中，从 PMHQ 用户信息中解码并暴露更多与业务和资料相关的用户属性（包括与 VIP 相关的字段）。
- 更新内部协议定义，以描述用户业务信息，用于解码 PMHQ 响应。

Build:
- 将项目版本从 7.12.8 升级到 7.12.9。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify user profile retrieval to rely on the PMHQ user info service and extend exposed user metadata across APIs while bumping the project version.

New Features:
- Expose VIP status, VIP level, and remark fields in the go-cqhttp stranger info API response.
- Include additional user metadata such as school and remark in user profile responses sourced from the PMHQ service.

Enhancements:
- Fallback to PMHQ user info when NT user detail lookup fails or lacks common extensions for group member info, ensuring more robust data retrieval.
- Decode and surface additional user business and profile properties (including VIP-related fields) from PMHQ user info in the shared user mixin.
- Update internal protocol definitions to describe user business information for decoding PMHQ responses.

Build:
- Bump project version from 7.12.8 to 7.12.9.

</details>