### PR TITLE
feat: add remote path mappings for split PMHQ deployments

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -119,12 +119,23 @@ export interface EmailConfig {
   to: string
 }
 
+export type PathStyle = 'posix' | 'win32'
+
+export interface RemotePathMapping {
+  name?: string
+  remotePrefix: string
+  localPrefix: string
+  remoteStyle: PathStyle
+  localStyle: PathStyle
+}
+
 export interface Config {
   milky: MilkyConfig
   satori: SatoriConfig
   ob11: OB11Config
   webui: WebUIConfig
   email?: EmailConfig
+  remotePathMappings: RemotePathMapping[]
   // onlyLocalhost: boolean
   enableLocalFile2Url?: boolean // 开启后，本地文件路径图片会转成http链接, 语音会转成base64
   log?: boolean

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './file'
+export * from './pathMapping'
 export * from './misc'
 export * from './misc'
 export { getVideoInfo } from './video'

--- a/src/common/utils/pathMapping.ts
+++ b/src/common/utils/pathMapping.ts
@@ -1,0 +1,129 @@
+import path from 'node:path'
+import { PathStyle, RemotePathMapping } from '@/common/types'
+
+type PathModule = typeof path.posix
+
+const pathModules: Record<PathStyle, PathModule> = {
+  posix: path.posix,
+  win32: path.win32,
+}
+
+export interface NormalizedRemotePathMapping extends RemotePathMapping {
+  remotePrefix: string
+  localPrefix: string
+}
+
+interface Direction {
+  sourcePrefix: string
+  sourceStyle: PathStyle
+  targetPrefix: string
+  targetStyle: PathStyle
+}
+
+export function normalizeRemotePathMappings(mappings: readonly RemotePathMapping[] = []): NormalizedRemotePathMapping[] {
+  return mappings.map(mapping => {
+    const remoteStyle = mapping.remoteStyle
+    const localStyle = mapping.localStyle
+
+    return {
+      ...mapping,
+      remoteStyle,
+      localStyle,
+      remotePrefix: normalizePrefix(mapping.remotePrefix, remoteStyle, 'remotePrefix'),
+      localPrefix: normalizePrefix(mapping.localPrefix, localStyle, 'localPrefix'),
+    }
+  })
+}
+
+export function mapRemotePathToLocal(filePath: string, mappings: readonly RemotePathMapping[] = []): string {
+  return mapPath(filePath, normalizeRemotePathMappings(mappings).map(mapping => ({
+    sourcePrefix: mapping.remotePrefix,
+    sourceStyle: mapping.remoteStyle,
+    targetPrefix: mapping.localPrefix,
+    targetStyle: mapping.localStyle,
+  })))
+}
+
+export function mapLocalPathToRemote(filePath: string, mappings: readonly RemotePathMapping[] = []): string {
+  return mapPath(filePath, normalizeRemotePathMappings(mappings).map(mapping => ({
+    sourcePrefix: mapping.localPrefix,
+    sourceStyle: mapping.localStyle,
+    targetPrefix: mapping.remotePrefix,
+    targetStyle: mapping.remoteStyle,
+  })))
+}
+
+function normalizePrefix(prefix: string, style: PathStyle, fieldName: string) {
+  if (!prefix) {
+    throw new Error(`remote path mapping ${fieldName} must not be empty`)
+  }
+
+  const pathModule = pathModules[style]
+  const normalized = stripTrailingSeparators(pathModule.normalize(prefix), style)
+  if (!pathModule.isAbsolute(normalized)) {
+    throw new Error(`remote path mapping ${fieldName} must be an absolute ${style} path: ${prefix}`)
+  }
+  return normalized
+}
+
+function mapPath(filePath: string, directions: Direction[]) {
+  let matched: Direction | undefined
+  let normalizedSourcePath = ''
+
+  for (const direction of directions) {
+    const pathModule = pathModules[direction.sourceStyle]
+    const candidate = pathModule.normalize(filePath)
+    if (!pathModule.isAbsolute(candidate)) {
+      continue
+    }
+    if (!isPrefixMatch(candidate, direction.sourcePrefix, direction.sourceStyle)) {
+      continue
+    }
+    if (!matched || direction.sourcePrefix.length > matched.sourcePrefix.length) {
+      matched = direction
+      normalizedSourcePath = candidate
+    }
+  }
+
+  if (!matched) {
+    return filePath
+  }
+
+  const rest = normalizedSourcePath.slice(matched.sourcePrefix.length)
+  const restParts = splitPathRest(rest, matched.sourceStyle)
+  return pathModules[matched.targetStyle].normalize(pathModules[matched.targetStyle].join(matched.targetPrefix, ...restParts))
+}
+
+function isPrefixMatch(filePath: string, prefix: string, style: PathStyle) {
+  const normalizedFilePath = style === 'win32' ? filePath.toLowerCase() : filePath
+  const normalizedPrefix = style === 'win32' ? prefix.toLowerCase() : prefix
+  if (normalizedFilePath === normalizedPrefix) {
+    return true
+  }
+
+  const root = pathModules[style].parse(prefix).root
+  if (prefix === root) {
+    return normalizedFilePath.startsWith(normalizedPrefix)
+  }
+
+  return normalizedFilePath.startsWith(normalizedPrefix + pathModules[style].sep)
+}
+
+function splitPathRest(rest: string, style: PathStyle) {
+  if (!rest) {
+    return []
+  }
+  if (style === 'win32') {
+    return rest.split(/[\\/]+/).filter(Boolean)
+  }
+  return rest.split('/').filter(Boolean)
+}
+
+function stripTrailingSeparators(input: string, style: PathStyle) {
+  const root = pathModules[style].parse(input).root
+  let output = input
+  while (output.length > root.length && output.endsWith(pathModules[style].sep)) {
+    output = output.slice(0, -1)
+  }
+  return output
+}

--- a/src/common/utils/pathMapping.ts
+++ b/src/common/utils/pathMapping.ts
@@ -20,6 +20,11 @@ interface Direction {
   targetStyle: PathStyle
 }
 
+export interface RemotePathMapper {
+  remotePathToLocal(filePath: string): string
+  localPathToRemote(filePath: string): string
+}
+
 export function normalizeRemotePathMappings(mappings: readonly RemotePathMapping[] = []): NormalizedRemotePathMapping[] {
   return mappings.map(mapping => {
     const remoteStyle = mapping.remoteStyle
@@ -35,22 +40,37 @@ export function normalizeRemotePathMappings(mappings: readonly RemotePathMapping
   })
 }
 
-export function mapRemotePathToLocal(filePath: string, mappings: readonly RemotePathMapping[] = []): string {
-  return mapPath(filePath, normalizeRemotePathMappings(mappings).map(mapping => ({
+export function createRemotePathMapper(mappings: readonly RemotePathMapping[] = []): RemotePathMapper {
+  const normalizedMappings = normalizeRemotePathMappings(mappings)
+  const remoteToLocalDirections = normalizedMappings.map(mapping => ({
     sourcePrefix: mapping.remotePrefix,
     sourceStyle: mapping.remoteStyle,
     targetPrefix: mapping.localPrefix,
     targetStyle: mapping.localStyle,
-  })))
-}
-
-export function mapLocalPathToRemote(filePath: string, mappings: readonly RemotePathMapping[] = []): string {
-  return mapPath(filePath, normalizeRemotePathMappings(mappings).map(mapping => ({
+  }))
+  const localToRemoteDirections = normalizedMappings.map(mapping => ({
     sourcePrefix: mapping.localPrefix,
     sourceStyle: mapping.localStyle,
     targetPrefix: mapping.remotePrefix,
     targetStyle: mapping.remoteStyle,
-  })))
+  }))
+
+  return {
+    remotePathToLocal(filePath: string) {
+      return mapPath(filePath, remoteToLocalDirections)
+    },
+    localPathToRemote(filePath: string) {
+      return mapPath(filePath, localToRemoteDirections)
+    },
+  }
+}
+
+export function mapRemotePathToLocal(filePath: string, mappings: readonly RemotePathMapping[] = []): string {
+  return createRemotePathMapper(mappings).remotePathToLocal(filePath)
+}
+
+export function mapLocalPathToRemote(filePath: string, mappings: readonly RemotePathMapping[] = []): string {
+  return createRemotePathMapper(mappings).localPathToRemote(filePath)
 }
 
 function normalizePrefix(prefix: string, style: PathStyle, fieldName: string) {

--- a/src/main/config/defaultConfig.ts
+++ b/src/main/config/defaultConfig.ts
@@ -35,6 +35,7 @@ export const defaultConfig: Config = {
   milky: milkyDefault,
   satori: satoriDefault,
   ob11: ob11Default,
+  remotePathMappings: [],
   enableLocalFile2Url: false,
   log: true,
   autoDeleteFile: false,

--- a/src/main/config/default_config.json
+++ b/src/main/config/default_config.json
@@ -75,6 +75,7 @@
       }
     ]
   },
+  "remotePathMappings": [],
   "enableLocalFile2Url": false,
   "log": true,
   "autoDeleteFile": false,

--- a/src/ntqqapi/api/file.ts
+++ b/src/ntqqapi/api/file.ts
@@ -14,6 +14,8 @@ import { selfInfo } from '@/common/globalVars'
 import { FlashFileListItem, FlashFileSetInfo } from '@/ntqqapi/types/flashfile'
 import { HighwayHttpSession, HighwayTcpSession } from '../helper/highway'
 import { Media } from '../proto'
+import { RemotePathMapping } from '@/common/types'
+import { mapLocalPathToRemote, mapRemotePathToLocal, NormalizedRemotePathMapping, normalizeRemotePathMappings } from '@/common/utils/pathMapping'
 
 declare module 'cordis' {
   interface Context {
@@ -22,13 +24,30 @@ declare module 'cordis' {
 }
 
 export class NTQQFileApi extends Service {
-  static inject = ['logger', 'pmhq']
+  static inject = ['logger', 'pmhq', 'config']
 
   rkeyManager: RkeyManager
+  private remotePathMappings: NormalizedRemotePathMapping[] = []
 
   constructor(protected ctx: Context) {
     super(ctx, 'ntFileApi')
     this.rkeyManager = new RkeyManager(ctx, 'https://llob.linyuchen.net/rkey')
+    this.setRemotePathMappings(ctx.config.get().remotePathMappings)
+    ctx.on('llob/config-updated', input => {
+      this.setRemotePathMappings(input.remotePathMappings)
+    })
+  }
+
+  setRemotePathMappings(mappings: readonly RemotePathMapping[] = []) {
+    this.remotePathMappings = normalizeRemotePathMappings(mappings)
+  }
+
+  remotePathToLocal(filePath: string) {
+    return mapRemotePathToLocal(filePath, this.remotePathMappings)
+  }
+
+  localPathToRemote(filePath: string) {
+    return mapLocalPathToRemote(filePath, this.remotePathMappings)
   }
 
   async getVideoUrl(fileUuid: string, isGroup: boolean) {
@@ -75,11 +94,13 @@ export class NTQQFileApi extends Service {
       fileName += ext ? '.' + ext : ''
     }
     const mediaPath = await this.getRichMediaFilePath(fileMd5, fileName, elementType, elementSubType)
-    await copyFile(filePath, mediaPath)
+    const localMediaPath = this.remotePathToLocal(mediaPath)
+    await copyFile(filePath, localMediaPath)
     return {
       md5: fileMd5,
       fileName,
       path: mediaPath,
+      localPath: localMediaPath,
     }
   }
 
@@ -274,16 +295,18 @@ export class NTQQFileApi extends Service {
   }
 
   async uploadGroupVideo(groupCode: string, filePath: string, thumbPath: string) {
-    const result = await this.ctx.pmhq.getGroupVideoUploadInfo(groupCode, filePath, thumbPath)
+    const localFilePath = this.remotePathToLocal(filePath)
+    const localThumbPath = this.remotePathToLocal(thumbPath)
+    const result = await this.ctx.pmhq.getGroupVideoUploadInfo(groupCode, localFilePath, localThumbPath)
     const highwaySession = await this.ctx.pmhq.getHighwaySession()
     const maxBlockSize = 1024 * 1024
     if (result.ext.uKey) {
       const { index } = result.ext.msgInfoBody[0]
-      result.ext.hash.fileSha1 = await calculateSha1StreamBytes(filePath)
+      result.ext.hash.fileSha1 = await calculateSha1StreamBytes(localFilePath)
       const trans = {
         uin: selfInfo.uin,
         cmd: 1005,
-        readable: createReadStream(filePath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localFilePath, { highWaterMark: maxBlockSize }),
         sum: Buffer.from(index.info.md5HexStr, 'hex'),
         size: index.info.fileSize,
         ticket: highwaySession.sigSession,
@@ -299,11 +322,11 @@ export class NTQQFileApi extends Service {
     }
     if (result.subExt.uKey) {
       const { index } = result.subExt.msgInfoBody[1]
-      result.subExt.hash.fileSha1 = await calculateSha1StreamBytes(thumbPath)
+      result.subExt.hash.fileSha1 = await calculateSha1StreamBytes(localThumbPath)
       const trans = {
         uin: selfInfo.uin,
         cmd: 1006,
-        readable: createReadStream(thumbPath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localThumbPath, { highWaterMark: maxBlockSize }),
         sum: Buffer.from(index.info.md5HexStr, 'hex'),
         size: index.info.fileSize,
         ticket: highwaySession.sigSession,
@@ -324,16 +347,18 @@ export class NTQQFileApi extends Service {
   }
 
   async uploadC2CVideo(peerUid: string, filePath: string, thumbPath: string) {
-    const result = await this.ctx.pmhq.getC2CVideoUploadInfo(peerUid, filePath, thumbPath)
+    const localFilePath = this.remotePathToLocal(filePath)
+    const localThumbPath = this.remotePathToLocal(thumbPath)
+    const result = await this.ctx.pmhq.getC2CVideoUploadInfo(peerUid, localFilePath, localThumbPath)
     const highwaySession = await this.ctx.pmhq.getHighwaySession()
     const maxBlockSize = 1024 * 1024
     if (result.ext.uKey) {
       const { index } = result.ext.msgInfoBody[0]
-      result.ext.hash.fileSha1 = await calculateSha1StreamBytes(filePath)
+      result.ext.hash.fileSha1 = await calculateSha1StreamBytes(localFilePath)
       const trans = {
         uin: selfInfo.uin,
         cmd: 1001,
-        readable: createReadStream(filePath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localFilePath, { highWaterMark: maxBlockSize }),
         sum: Buffer.from(index.info.md5HexStr, 'hex'),
         size: index.info.fileSize,
         ticket: highwaySession.sigSession,
@@ -349,11 +374,11 @@ export class NTQQFileApi extends Service {
     }
     if (result.subExt.uKey) {
       const { index } = result.subExt.msgInfoBody[1]
-      result.subExt.hash.fileSha1 = await calculateSha1StreamBytes(thumbPath)
+      result.subExt.hash.fileSha1 = await calculateSha1StreamBytes(localThumbPath)
       const trans = {
         uin: selfInfo.uin,
         cmd: 1002,
-        readable: createReadStream(thumbPath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localThumbPath, { highWaterMark: maxBlockSize }),
         sum: Buffer.from(index.info.md5HexStr, 'hex'),
         size: index.info.fileSize,
         ticket: highwaySession.sigSession,
@@ -374,7 +399,8 @@ export class NTQQFileApi extends Service {
   }
 
   async uploadGroupFile(groupCode: string, filePath: string, fileName: string, parentFolderId = '/') {
-    const result = await this.ctx.pmhq.getGroupFileUploadInfo(groupCode, filePath, fileName, parentFolderId)
+    const localFilePath = this.remotePathToLocal(filePath)
+    const result = await this.ctx.pmhq.getGroupFileUploadInfo(groupCode, localFilePath, fileName, parentFolderId)
     if (!result.fileExist) {
       const highwaySession = await this.ctx.pmhq.getHighwaySession()
       const ext = Media.FileUploadExt.encode({
@@ -418,7 +444,7 @@ export class NTQQFileApi extends Service {
       const trans = {
         uin: selfInfo.uin,
         cmd: 71,
-        readable: createReadStream(filePath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localFilePath, { highWaterMark: maxBlockSize }),
         sum: result.md5,
         size: result.fileSize,
         ticket: highwaySession.sigSession,
@@ -439,7 +465,8 @@ export class NTQQFileApi extends Service {
   }
 
   async uploadC2CFile(peerUid: string, filePath: string, fileName: string) {
-    const result = await this.ctx.pmhq.getC2CFileUploadInfo(peerUid, filePath, fileName)
+    const localFilePath = this.remotePathToLocal(filePath)
+    const result = await this.ctx.pmhq.getC2CFileUploadInfo(peerUid, localFilePath, fileName)
     const highwaySession = await this.ctx.pmhq.getHighwaySession()
     const ext = Media.FileUploadExt.encode({
       unknown1: 100,
@@ -483,7 +510,7 @@ export class NTQQFileApi extends Service {
     const trans = {
       uin: selfInfo.uin,
       cmd: 95,
-      readable: createReadStream(filePath, { highWaterMark: maxBlockSize }),
+      readable: createReadStream(localFilePath, { highWaterMark: maxBlockSize }),
       sum: result.md5CheckSum,
       size: result.fileSize,
       ticket: highwaySession.sigSession,
@@ -504,7 +531,8 @@ export class NTQQFileApi extends Service {
   }
 
   async uploadGroupImage(groupCode: string, filePath: string) {
-    const result = await this.ctx.pmhq.getGroupImageUploadInfo(groupCode, filePath)
+    const localFilePath = this.remotePathToLocal(filePath)
+    const result = await this.ctx.pmhq.getGroupImageUploadInfo(groupCode, localFilePath)
     const highwaySession = await this.ctx.pmhq.getHighwaySession()
     const maxBlockSize = 1024 * 1024
     if (result.ext.uKey) {
@@ -512,7 +540,7 @@ export class NTQQFileApi extends Service {
       const trans = {
         uin: selfInfo.uin,
         cmd: 1004,
-        readable: createReadStream(filePath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localFilePath, { highWaterMark: maxBlockSize }),
         sum: Buffer.from(index.info.md5HexStr, 'hex'),
         size: index.info.fileSize,
         ticket: highwaySession.sigSession,
@@ -533,7 +561,8 @@ export class NTQQFileApi extends Service {
   }
 
   async uploadC2CImage(peerUid: string, filePath: string) {
-    const result = await this.ctx.pmhq.getC2CImageUploadInfo(peerUid, filePath)
+    const localFilePath = this.remotePathToLocal(filePath)
+    const result = await this.ctx.pmhq.getC2CImageUploadInfo(peerUid, localFilePath)
     const highwaySession = await this.ctx.pmhq.getHighwaySession()
     const maxBlockSize = 1024 * 1024
     if (result.ext.uKey) {
@@ -541,7 +570,7 @@ export class NTQQFileApi extends Service {
       const trans = {
         uin: selfInfo.uin,
         cmd: 1003,
-        readable: createReadStream(filePath, { highWaterMark: maxBlockSize }),
+        readable: createReadStream(localFilePath, { highWaterMark: maxBlockSize }),
         sum: Buffer.from(index.info.md5HexStr, 'hex'),
         size: index.info.fileSize,
         ticket: highwaySession.sigSession,

--- a/src/ntqqapi/api/file.ts
+++ b/src/ntqqapi/api/file.ts
@@ -15,7 +15,7 @@ import { FlashFileListItem, FlashFileSetInfo } from '@/ntqqapi/types/flashfile'
 import { HighwayHttpSession, HighwayTcpSession } from '../helper/highway'
 import { Media } from '../proto'
 import { RemotePathMapping } from '@/common/types'
-import { mapLocalPathToRemote, mapRemotePathToLocal, NormalizedRemotePathMapping, normalizeRemotePathMappings } from '@/common/utils/pathMapping'
+import { createRemotePathMapper, RemotePathMapper } from '@/common/utils/pathMapping'
 
 declare module 'cordis' {
   interface Context {
@@ -27,7 +27,7 @@ export class NTQQFileApi extends Service {
   static inject = ['logger', 'pmhq', 'config']
 
   rkeyManager: RkeyManager
-  private remotePathMappings: NormalizedRemotePathMapping[] = []
+  private remotePathMapper: RemotePathMapper = createRemotePathMapper()
 
   constructor(protected ctx: Context) {
     super(ctx, 'ntFileApi')
@@ -39,15 +39,15 @@ export class NTQQFileApi extends Service {
   }
 
   setRemotePathMappings(mappings: readonly RemotePathMapping[] = []) {
-    this.remotePathMappings = normalizeRemotePathMappings(mappings)
+    this.remotePathMapper = createRemotePathMapper(mappings)
   }
 
   remotePathToLocal(filePath: string) {
-    return mapRemotePathToLocal(filePath, this.remotePathMappings)
+    return this.remotePathMapper.remotePathToLocal(filePath)
   }
 
   localPathToRemote(filePath: string) {
-    return mapLocalPathToRemote(filePath, this.remotePathMappings)
+    return this.remotePathMapper.localPathToRemote(filePath)
   }
 
   async getVideoUrl(fileUuid: string, isGroup: boolean) {

--- a/src/ntqqapi/core.ts
+++ b/src/ntqqapi/core.ts
@@ -100,7 +100,7 @@ class Core extends Service {
     this.messageSentCount++
     ctx.logger.info('消息发送', peer)
     deleteAfterSentFiles.forEach(path => {
-      unlink(path).catch(noop)
+      unlink(ctx.ntFileApi.remotePathToLocal(path)).catch(noop)
     })
     return returnMsg
   }
@@ -151,7 +151,8 @@ class Core extends Service {
       setTimeout(() => {
         for (const path of allPaths) {
           if (path) {
-            unlink(path).then(() => this.ctx.logger.info('删除文件成功', path)).catch(noop)
+            const localPath = this.ctx.ntFileApi.remotePathToLocal(path)
+            unlink(localPath).then(() => this.ctx.logger.info('删除文件成功', localPath)).catch(noop)
           }
         }
       }, this.config.autoDeleteFileSecond! * 1000)

--- a/src/ntqqapi/entities.ts
+++ b/src/ntqqapi/entities.ts
@@ -125,35 +125,36 @@ export namespace SendElement {
     if (fileSize > 1024 * 1024 * maxMB) {
       throw new Error(`视频过大，最大支持${maxMB}MB，当前文件大小${fileSize}B`)
     }
-    const { fileName, path, md5 } = await ctx.ntFileApi.uploadFile(filePath, ElementType.Video)
+    const { fileName, path, localPath, md5 } = await ctx.ntFileApi.uploadFile(filePath, ElementType.Video)
     let videoInfo = {
       width: 1920,
       height: 1080,
       time: 15,
       format: 'mp4',
       size: fileSize,
-      filePath,
+      filePath: localPath,
     }
     try {
-      videoInfo = await getVideoInfo(path)
+      videoInfo = await getVideoInfo(localPath)
       ctx.logger.info('视频信息', videoInfo)
     } catch (e) {
       ctx.logger.info('获取视频信息失败', e)
     }
     const thumbDir = pathLib.dirname(path.replaceAll('\\', '/').replace(`/Ori/`, `/Thumb/`))
     const thumbFilePath = pathLib.join(thumbDir, `${md5}_0.png`)
-    await mkdir(thumbDir, { recursive: true })
+    const localThumbFilePath = ctx.ntFileApi.remotePathToLocal(thumbFilePath)
+    await mkdir(pathLib.dirname(localThumbFilePath), { recursive: true })
     if (diyThumbPath) {
-      await copyFile(diyThumbPath, thumbFilePath)
+      await copyFile(diyThumbPath, localThumbFilePath)
     } else {
       const path = await createThumb(ctx, videoInfo.filePath)
-      await copyFile(path, thumbFilePath)
+      await copyFile(path, localThumbFilePath)
       unlink(path).catch(noop)
     }
     const thumbPath = new Map()
-    const thumbSize = (await stat(thumbFilePath)).size
+    const thumbSize = (await stat(localThumbFilePath)).size
     thumbPath.set(0, thumbFilePath)
-    const thumbMd5 = await getMd5HexFromFile(thumbFilePath)
+    const thumbMd5 = await getMd5HexFromFile(localThumbFilePath)
     const element: SendVideoElement = {
       elementType: ElementType.Video,
       elementId: '',

--- a/src/onebot11/action/llbot/system/Config.ts
+++ b/src/onebot11/action/llbot/system/Config.ts
@@ -27,10 +27,10 @@ export class SetConfigAction extends BaseAction<Config, null> {
     msgCacheExpire: Schema.number(),
     remotePathMappings: Schema.array(Schema.object({
       name: Schema.string(),
-      remotePrefix: Schema.string(),
-      localPrefix: Schema.string(),
-      remoteStyle: Schema.union(['posix', 'win32']),
-      localStyle: Schema.union(['posix', 'win32']),
+      remotePrefix: Schema.string().required(),
+      localPrefix: Schema.string().required(),
+      remoteStyle: Schema.union(['posix', 'win32']).required(),
+      localStyle: Schema.union(['posix', 'win32']).required(),
     })),
     rawMsgPB: Schema.boolean()
   })

--- a/src/onebot11/action/llbot/system/Config.ts
+++ b/src/onebot11/action/llbot/system/Config.ts
@@ -25,6 +25,13 @@ export class SetConfigAction extends BaseAction<Config, null> {
     ffmpeg: Schema.string(),
     musicSignUrl: Schema.string(),
     msgCacheExpire: Schema.number(),
+    remotePathMappings: Schema.array(Schema.object({
+      name: Schema.string(),
+      remotePrefix: Schema.string(),
+      localPrefix: Schema.string(),
+      remoteStyle: Schema.union(['posix', 'win32']),
+      localStyle: Schema.union(['posix', 'win32']),
+    })),
     rawMsgPB: Schema.boolean()
   })
 

--- a/src/satori/message.ts
+++ b/src/satori/message.ts
@@ -62,7 +62,7 @@ export class MessageEncoder {
       }
     }
     this.deleteAfterSentFiles.forEach(path => {
-      unlink(path).catch(noop)
+      unlink(this.ctx.ntFileApi.remotePathToLocal(path)).catch(noop)
     })
     this.deleteAfterSentFiles = []
     this.elements = []

--- a/src/webui/BE/routes/webqq/proxy.ts
+++ b/src/webui/BE/routes/webqq/proxy.ts
@@ -16,7 +16,7 @@ export function createProxyRoutes(ctx: Context): Hono {
         return c.json({ success: false, message: '缺少文件路径参数' }, 400)
       }
 
-      const normalizedPath = path.normalize(filePath)
+      const normalizedPath = path.normalize(ctx.ntFileApi.remotePathToLocal(filePath))
       if (!existsSync(normalizedPath)) {
         return c.json({ success: false, message: '文件不存在' }, 404)
       }
@@ -130,7 +130,7 @@ export function createProxyRoutes(ctx: Context): Hono {
 
       // 优先使用本地文件路径
       if (filePath) {
-        const decodedPath = decodeURIComponent(filePath)
+        const decodedPath = ctx.ntFileApi.remotePathToLocal(decodeURIComponent(filePath))
         try {
           await fs.access(decodedPath)
           audioFilePath = decodedPath

--- a/test/unit/configSchema.test.ts
+++ b/test/unit/configSchema.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { SetConfigAction } from '@/onebot11/action/llbot/system/Config'
+
+function getSetConfigPayloadSchema() {
+  return new SetConfigAction({ ctx: {} } as any).payloadSchema!
+}
+
+describe('set_config schema', () => {
+  it('accepts remote path mappings without a display name', () => {
+    const schema = getSetConfigPayloadSchema()
+
+    expect(() => new schema({
+      remotePathMappings: [{
+        remotePrefix: '/root/.config/QQ',
+        localPrefix: '/host/qq',
+        remoteStyle: 'posix',
+        localStyle: 'posix',
+      }],
+    } as any)).not.toThrow()
+  })
+
+  it('requires the structural remote path mapping fields', () => {
+    const schema = getSetConfigPayloadSchema()
+
+    expect(() => new schema({
+      remotePathMappings: [{
+        localPrefix: '/host/qq',
+        remoteStyle: 'posix',
+        localStyle: 'posix',
+      }],
+    } as any)).toThrow(/remotePrefix.*missing required value/)
+    expect(() => new schema({
+      remotePathMappings: [{
+        remotePrefix: '/root/.config/QQ',
+        localPrefix: '/host/qq',
+        localStyle: 'posix',
+      }],
+    } as any)).toThrow(/remoteStyle.*missing required value/)
+  })
+})

--- a/test/unit/ntqqFileApi.test.ts
+++ b/test/unit/ntqqFileApi.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { ElementType } from '@/ntqqapi/types'
+import { NTQQFileApi } from '@/ntqqapi/api/file'
+
+describe('NTQQFileApi', () => {
+  it('copies rich media to the mapped local path and keeps the PMHQ path in the send element payload', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'llbot-file-api-'))
+    try {
+      const inputPath = path.join(tempDir, 'input.txt')
+      const localRoot = path.join(tempDir, 'qq-volume')
+      const remotePath = '/root/.config/QQ/nt_data/Pic/Ori/input.txt'
+      const localMediaPath = path.join(localRoot, 'nt_data/Pic/Ori/input.txt')
+      await mkdir(path.dirname(localMediaPath), { recursive: true })
+      await writeFile(inputPath, 'mapped-media')
+
+      const api = Object.create(NTQQFileApi.prototype) as NTQQFileApi
+      ;(api as any).setRemotePathMappings([{
+        remotePrefix: '/root/.config/QQ',
+        localPrefix: localRoot,
+        remoteStyle: 'posix',
+        localStyle: 'posix',
+      }])
+      api.getRichMediaFilePath = vi.fn(async () => remotePath)
+
+      const uploaded = await api.uploadFile(inputPath, ElementType.Pic)
+
+      expect(uploaded.path).toBe(remotePath)
+      expect(uploaded.localPath).toBe(localMediaPath)
+      expect(await readFile(localMediaPath, 'utf8')).toBe('mapped-media')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/unit/ntqqFileApi.test.ts
+++ b/test/unit/ntqqFileApi.test.ts
@@ -29,9 +29,36 @@ describe('NTQQFileApi', () => {
 
       expect(uploaded.path).toBe(remotePath)
       expect(uploaded.localPath).toBe(localMediaPath)
+      expect(api.localPathToRemote(localMediaPath)).toBe(remotePath)
       expect(await readFile(localMediaPath, 'utf8')).toBe('mapped-media')
     } finally {
       await rm(tempDir, { recursive: true, force: true })
     }
+  })
+
+  it('rebuilds its path mapper when remotePathMappings change', () => {
+    const api = Object.create(NTQQFileApi.prototype) as NTQQFileApi
+
+    ;(api as any).setRemotePathMappings([{
+      remotePrefix: '/root/.config/QQ',
+      localPrefix: '/host/qq',
+      remoteStyle: 'posix',
+      localStyle: 'posix',
+    }])
+    expect(api.remotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png'))
+      .toBe('/host/qq/nt_data/Pic/Ori/a.png')
+    expect(api.localPathToRemote('/host/qq/nt_data/Pic/Ori/a.png'))
+      .toBe('/root/.config/QQ/nt_data/Pic/Ori/a.png')
+
+    ;(api as any).setRemotePathMappings([{
+      remotePrefix: '/root/.config/QQ',
+      localPrefix: 'D:\\QQProfile',
+      remoteStyle: 'posix',
+      localStyle: 'win32',
+    }])
+    expect(api.remotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png'))
+      .toBe('D:\\QQProfile\\nt_data\\Pic\\Ori\\a.png')
+    expect(api.localPathToRemote('d:\\qqprofile\\nt_data\\Pic\\Ori\\a.png'))
+      .toBe('/root/.config/QQ/nt_data/Pic/Ori/a.png')
   })
 })

--- a/test/unit/pathMapping.test.ts
+++ b/test/unit/pathMapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mapLocalPathToRemote, mapRemotePathToLocal } from '@/common/utils/pathMapping'
+import { createRemotePathMapper, mapLocalPathToRemote, mapRemotePathToLocal } from '@/common/utils/pathMapping'
 import { RemotePathMapping } from '@/common/types'
 
 describe('remote path mappings', () => {
@@ -11,7 +11,9 @@ describe('remote path mappings', () => {
       localStyle: 'posix',
     }]
 
-    expect(mapRemotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png', mappings))
+    const mapper = createRemotePathMapper(mappings)
+
+    expect(mapper.remotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png'))
       .toBe('/var/lib/containers/storage/volumes/llbot_qq/_data/nt_data/Pic/Ori/a.png')
   })
 
@@ -31,9 +33,11 @@ describe('remote path mappings', () => {
       },
     ]
 
-    expect(mapRemotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png', mappings))
+    const mapper = createRemotePathMapper(mappings)
+
+    expect(mapper.remotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png'))
       .toBe('/host/qq-data/Pic/Ori/a.png')
-    expect(mapRemotePathToLocal('/root/.config/QQ2/nt_data/Pic/Ori/a.png', mappings))
+    expect(mapper.remotePathToLocal('/root/.config/QQ2/nt_data/Pic/Ori/a.png'))
       .toBe('/root/.config/QQ2/nt_data/Pic/Ori/a.png')
   })
 
@@ -45,9 +49,39 @@ describe('remote path mappings', () => {
       localStyle: 'win32',
     }]
 
+    const mapper = createRemotePathMapper(mappings)
+
+    expect(mapper.remotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png'))
+      .toBe('D:\\QQProfile\\nt_data\\Pic\\Ori\\a.png')
+    expect(mapper.localPathToRemote('d:\\qqprofile\\nt_data\\Pic\\Ori\\a.png'))
+      .toBe('/root/.config/QQ/nt_data/Pic/Ori/a.png')
+  })
+
+  it('normalizes mapping prefixes when the mapper is created', () => {
+    const mapper = createRemotePathMapper([{
+      remotePrefix: '/root/.config/QQ/',
+      localPrefix: '/host/qq/',
+      remoteStyle: 'posix',
+      localStyle: 'posix',
+    }])
+
+    expect(mapper.remotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png'))
+      .toBe('/host/qq/nt_data/Pic/Ori/a.png')
+    expect(mapper.localPathToRemote('/host/qq/nt_data/Pic/Ori/a.png'))
+      .toBe('/root/.config/QQ/nt_data/Pic/Ori/a.png')
+  })
+
+  it('keeps one-shot mapping helpers for direct callers', () => {
+    const mappings: RemotePathMapping[] = [{
+      remotePrefix: '/root/.config/QQ',
+      localPrefix: 'D:\\QQProfile',
+      remoteStyle: 'posix',
+      localStyle: 'win32',
+    }]
+
     expect(mapRemotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png', mappings))
       .toBe('D:\\QQProfile\\nt_data\\Pic\\Ori\\a.png')
-    expect(mapLocalPathToRemote('d:\\qqprofile\\nt_data\\Pic\\Ori\\a.png', mappings))
+    expect(mapLocalPathToRemote('D:\\QQProfile\\nt_data\\Pic\\Ori\\a.png', mappings))
       .toBe('/root/.config/QQ/nt_data/Pic/Ori/a.png')
   })
 })

--- a/test/unit/pathMapping.test.ts
+++ b/test/unit/pathMapping.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { mapLocalPathToRemote, mapRemotePathToLocal } from '@/common/utils/pathMapping'
+import { RemotePathMapping } from '@/common/types'
+
+describe('remote path mappings', () => {
+  it('maps a PMHQ container path to a host-mounted local path', () => {
+    const mappings: RemotePathMapping[] = [{
+      remotePrefix: '/root/.config/QQ',
+      localPrefix: '/var/lib/containers/storage/volumes/llbot_qq/_data',
+      remoteStyle: 'posix',
+      localStyle: 'posix',
+    }]
+
+    expect(mapRemotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png', mappings))
+      .toBe('/var/lib/containers/storage/volumes/llbot_qq/_data/nt_data/Pic/Ori/a.png')
+  })
+
+  it('uses the longest matching prefix and enforces path boundaries', () => {
+    const mappings: RemotePathMapping[] = [
+      {
+        remotePrefix: '/root/.config/QQ',
+        localPrefix: '/host/qq',
+        remoteStyle: 'posix',
+        localStyle: 'posix',
+      },
+      {
+        remotePrefix: '/root/.config/QQ/nt_data',
+        localPrefix: '/host/qq-data',
+        remoteStyle: 'posix',
+        localStyle: 'posix',
+      },
+    ]
+
+    expect(mapRemotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png', mappings))
+      .toBe('/host/qq-data/Pic/Ori/a.png')
+    expect(mapRemotePathToLocal('/root/.config/QQ2/nt_data/Pic/Ori/a.png', mappings))
+      .toBe('/root/.config/QQ2/nt_data/Pic/Ori/a.png')
+  })
+
+  it('maps between POSIX and Windows path styles', () => {
+    const mappings: RemotePathMapping[] = [{
+      remotePrefix: '/root/.config/QQ',
+      localPrefix: 'D:\\QQProfile',
+      remoteStyle: 'posix',
+      localStyle: 'win32',
+    }]
+
+    expect(mapRemotePathToLocal('/root/.config/QQ/nt_data/Pic/Ori/a.png', mappings))
+      .toBe('D:\\QQProfile\\nt_data\\Pic\\Ori\\a.png')
+    expect(mapLocalPathToRemote('d:\\qqprofile\\nt_data\\Pic\\Ori\\a.png', mappings))
+      .toBe('/root/.config/QQ/nt_data/Pic/Ori/a.png')
+  })
+})


### PR DESCRIPTION
Summary

这个 PR 增加了一个通用的 `remotePathMappings` 配置，用于支持 LLBot 进程和 PMHQ/QQ 运行在不同文件系统命名空间时的媒体路径映射。

典型场景是：PMHQ 运行在容器中，返回 `/root/.config/QQ/...` 这类容器内路径；LLBot 运行在宿主机进程中，直接对该路径执行 `copyFile`、`stat`、`createReadStream` 会失败。现在 LLBot 可以通过显式配置把 PMHQ 返回的远端路径映射到 LLBot 本地可访问路径，同时在消息元素中继续保留 PMHQ/QQ 需要的原始路径。

Motivation

我们在部署中采用了“LLBot 宿主机进程 + PMHQ 容器”的运行方式。

这样做的背景是：早期 LLBot 和 PMHQ 都运行在 Podman 容器中，但实际运维中遇到过一些和业务无关的容器层问题，例如：

- LLBot 容器必须通过 Podman 网络 DNS 解析 `pmhq:13000`。
- `podman-compose` / rootless Podman 下网络附着、服务别名、host loopback 暴露和部署验证比较容易产生不确定性。
- LLBot 本身只是 Node 协议适配服务，但放在容器里后，需要额外处理容器网络、端口转发、运行时配置重写、健康检查和部署 verifier。
- Koishi 和 LLBot 都是普通宿主机后端进程，把 LLBot 放在宿主机后，Koishi 可以直接连接 `127.0.0.1:3001`，LLBot 也可以直接连接 PMHQ 暴露到宿主机的 `127.0.0.1:${PMHQ_PORT}`，整体运行边界更清晰。

同时，PMHQ 仍然适合保留在容器中，因为它承载的是 QQ 客户端运行时、登录态、Xvfb/图形环境和 QQ 数据目录。这个部分更需要容器隔离，也更适合独立重启和排障。

这个运行方式清理了网络和部署层的不确定性，但也暴露出一个新的边界：LLBot 和 PMHQ 不再共享同一个文件系统命名空间。PMHQ 返回的 `/root/.config/QQ/...` 对 PMHQ 容器是正确路径，但对宿主机 LLBot 进程不是可直接访问路径。

因此，这个 PR 的目标不是为某个部署脚本写死特殊逻辑，而是让 LLBot 正式支持“远端运行时路径”和“本地进程路径”不同的部署拓扑。

Design

这个 PR 采用显式配置，而不是自动探测容器环境。

新增配置示例：

```json
{
  "remotePathMappings": [
    {
      "name": "pmhq-qq-root",
      "remotePrefix": "/root/.config/QQ",
      "localPrefix": "/var/lib/containers/storage/volumes/qqbot-stack_qq_volume/_data",
      "remoteStyle": "posix",
      "localStyle": "posix"
    }
  ]
}
```

设计原则：

- LLBot 只提供通用路径映射能力，不内置 Podman、Docker 或某个部署项目的探测逻辑。
- 部署系统负责决定 `remotePrefix` 和 `localPrefix` 的实际值。
- 默认 `remotePathMappings: []`，未配置时保持现有同命名空间行为。
- 映射支持 `posix` 和 `win32` 路径风格。
- 使用最长前缀匹配，并检查路径边界，避免误匹配类似 `/root/.config/QQ2` 的路径。
- 本地文件系统操作使用映射后的本地路径。
- 发送给 PMHQ/QQ 的消息元素仍保留 PMHQ 返回的远端路径。

Changes

- 新增 `remotePathMappings` 顶层配置。
- 新增通用路径映射工具。
- `NTQQFileApi.uploadFile()` 复制文件时使用本地映射路径，但返回的消息路径保持 PMHQ 原路径。
- 图片、视频、语音、文件上传中的本地读写路径统一经过映射处理。
- 视频缩略图写入和读取区分本地路径与远端路径。
- 自动删除、Satori 清理、WebUI 文件/语音代理接入同一映射能力。
- `set_config` schema 补充 `remotePathMappings` 字段。
- 增加路径映射和富媒体上传相关单元测试。

Why this belongs in LLBot

PMHQ 返回的是它自身运行环境中的 QQ 数据目录路径，这对 PMHQ 来说是合理的。真正同时需要理解“PMHQ 返回路径”和“LLBot 本地可访问路径”的组件是 LLBot，因为 LLBot 会：

- 调用 PMHQ 获取媒体目标路径。
- 把待发送文件复制到该目标位置。
- 构造图片、视频、语音等消息元素。
- 对媒体文件执行 `stat`、hash、缩略图生成、`createReadStream` 等本地操作。

因此，这个能力放在 LLBot 的文件 API 层更合适。它把部署拓扑中的路径边界显式建模，而不是要求每个部署项目去修改打包后的 `llbot.js` 或在外部做文本 patch。

Compatibility

默认配置为空数组，因此现有 LLBot 和 PMHQ 运行在同一文件系统命名空间的部署方式不会受到影响。

对于容器化 PMHQ + 宿主机 LLBot 的部署，部署系统可以在生成配置时写入合适的映射。这个 PR 不假设具体容器运行时，也不依赖 Podman/Docker API。

Testing

- `npx vitest run --config vitest.config.ts test/unit`
- `npx vite build`

## Summary by Sourcery

添加可配置的远程到本地路径映射，并在 NTQQ 文件/媒体处理链路中统一应用，以便在 PMHQ 运行于独立文件系统命名空间时，LLBot 仍能正常工作。

新功能：
- 引入顶层配置项 `remotePathMappings`，支持 POSIX 和 Windows 路径风格，用于将远程 QQ/PMHQ 路径映射到本地可访问路径。

增强改进：
- 在 `NTQQFileApi` 内对所有媒体上传、哈希计算、流式传输、缩略图生成以及自动文件清理流程中规范化并应用远程/本地路径映射，同时在消息负载中保留原始远程路径。
- 在运行时配置 schema 和默认配置中暴露 `remotePathMappings`，并新增共享的 `pathMapping` 工具，用于双向路径转换，供核心消息处理逻辑和 WebUI 代理路由共用。

测试：
- 为 `NTQQFileApi` 的路径映射行为以及通用的 `pathMapping` 工具添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable remote-to-local path mappings and apply them across NTQQ file/media handling so LLBot can operate when PMHQ runs in a separate filesystem namespace.

New Features:
- Introduce a top-level remotePathMappings configuration supporting POSIX and Windows path styles for mapping remote QQ/PMHQ paths to locally accessible paths.

Enhancements:
- Normalize and apply remote/local path mappings inside NTQQFileApi for all media uploads, hashing, streaming, thumbnail generation, and automatic file cleanup while preserving remote paths in message payloads.
- Expose remotePathMappings in runtime configuration schema and default configuration, and add a shared pathMapping utility for bidirectional path conversion used by core messaging and WebUI proxy routes.

Tests:
- Add unit tests for NTQQFileApi path mapping behavior and for the generic pathMapping utility.

</details>

新功能：
- 添加顶层的 `remotePathMappings` 配置，支持 POSIX 和 Windows 风格的路径前缀，并支持最长前缀匹配。

改进：
- 将远程到本地路径映射集成到 `NTQQFileApi` 中，使所有媒体上传、哈希计算、流式传输、缩略图生成、删除以及 WebUI/Satori 代理操作都使用本地可访问路径，同时在消息负载中保留远程路径。
- 在运行时配置模式（schema）和默认配置中暴露 `remotePathMappings`，并添加共享的 `pathMapping` 工具，用于双向路径转换。

测试：
- 为 `NTQQFileApi` 的路径映射行为以及通用的 `pathMapping` 工具添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加可配置的远程到本地路径映射，并在 NTQQ 文件/媒体处理链路中统一应用，以便在 PMHQ 运行于独立文件系统命名空间时，LLBot 仍能正常工作。

新功能：
- 引入顶层配置项 `remotePathMappings`，支持 POSIX 和 Windows 路径风格，用于将远程 QQ/PMHQ 路径映射到本地可访问路径。

增强改进：
- 在 `NTQQFileApi` 内对所有媒体上传、哈希计算、流式传输、缩略图生成以及自动文件清理流程中规范化并应用远程/本地路径映射，同时在消息负载中保留原始远程路径。
- 在运行时配置 schema 和默认配置中暴露 `remotePathMappings`，并新增共享的 `pathMapping` 工具，用于双向路径转换，供核心消息处理逻辑和 WebUI 代理路由共用。

测试：
- 为 `NTQQFileApi` 的路径映射行为以及通用的 `pathMapping` 工具添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable remote-to-local path mappings and apply them across NTQQ file/media handling so LLBot can operate when PMHQ runs in a separate filesystem namespace.

New Features:
- Introduce a top-level remotePathMappings configuration supporting POSIX and Windows path styles for mapping remote QQ/PMHQ paths to locally accessible paths.

Enhancements:
- Normalize and apply remote/local path mappings inside NTQQFileApi for all media uploads, hashing, streaming, thumbnail generation, and automatic file cleanup while preserving remote paths in message payloads.
- Expose remotePathMappings in runtime configuration schema and default configuration, and add a shared pathMapping utility for bidirectional path conversion used by core messaging and WebUI proxy routes.

Tests:
- Add unit tests for NTQQFileApi path mapping behavior and for the generic pathMapping utility.

</details>

</details>